### PR TITLE
Add coda-dev install script + fix v2/v3 doc drift (#178)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ from that run.
 | Vet         | `go vet ./...`       | <1s    | Always run. No output on success. |
 | Test        | `go test ./...`      | <1s    | Packages with no tests print `[no test files]`; not a failure. |
 | Tidy check  | `go mod tidy`        | <1s    | Must leave `go.mod` and `go.sum` unchanged. See trap 2. |
-| Binary      | `go build -o coda ./cmd/coda && ./coda version` | <1s | Prints `dev` unless `-ldflags "-X main.Version=..."` is set. |
+| Binary      | `go build -o coda-dev ./cmd/coda && ./coda-dev version` | <1s | Prints `dev` unless `-ldflags "-X main.Version=..."` is set (the install script does this). |
 
 **Minimum gate before opening a PR:**
 
@@ -58,7 +58,7 @@ focus card explicitly asks for them.
 
 ### First-run side effects
 
-`coda version` is pure; it does not touch disk. `coda agent ...`
+`coda-dev version` is pure; it does not touch disk. `coda-dev agent ...`
 commands open or create `$XDG_STATE_HOME/coda/coda.db` (default
 `~/.local/state/coda/coda.db`) and run pending migrations. The
 containing directory is created if missing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,4 +74,6 @@ before inferring.
 ## Status
 
 v3 scaffold. Session/identity/messages/plugin/feature/db packages are
-stubs. `coda version` is the only working command.
+stubs. `coda-dev version` is the only working command (post-install).
+
+Install: `./scripts/install.sh` (drops `coda-dev` in `$XDG_BIN_HOME`).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve repo root (script lives in scripts/, repo is one dir up)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+VERSION="$(git describe --tags --dirty --always 2>/dev/null || echo dev)"
+DEST="${XDG_BIN_HOME:-$HOME/.local/bin}"
+BINARY="coda-dev"
+
+mkdir -p "$DEST"
+go build -ldflags "-X main.Version=$VERSION" -o "$DEST/$BINARY" ./cmd/coda
+echo "installed: $DEST/$BINARY ($VERSION)"
+
+# Collision warning: v2 shell-functions.sh defines a function named
+# 'coda-dev'. In interactive bash it shadows this binary because bash
+# resolves functions before $PATH. Warn the user; do not block install.
+if [ -n "${BASH_VERSION:-}" ] && type coda-dev 2>/dev/null | grep -q 'is a function'; then
+    cat <<EOF >&2
+
+warning: a shell function named 'coda-dev' is defined in your shell.
+         it will shadow $DEST/$BINARY in interactive shells, so
+         'coda-dev version' will run the v2 shim, not v3.
+
+         to invoke v3 explicitly:
+             $DEST/$BINARY version
+
+         to fix permanently, see card #183 (rename or remove the v2
+         coda-dev shell function).
+EOF
+fi


### PR DESCRIPTION
## Summary
- New `scripts/install.sh`: builds the v3 binary, version-stamps via `-ldflags` from `git describe`, and installs it as `coda-dev` in `$XDG_BIN_HOME` (default `~/.local/bin`).
- The script warns (non-fatally) when interactive bash has a v2 `coda-dev` shell function defined, which would shadow the binary on `$PATH`. Permanent fix tracked in #183.
- Fixes doc drift in `AGENTS.md` and `.github/copilot-instructions.md` that still referred to the binary as `coda`; updated to `coda-dev` (post-install).
- Adds a one-line install reference to AGENTS.md status section.

## Why coda-dev (not coda)
The host system has a v2 bash CLI named `coda` and a v2 shell function named `coda-dev` sourced from `shell-functions.sh`. Installing the v3 binary as `coda` would silently shadow the v2 daily-workflow CLI. Until v3 reaches parity, the explicit `coda-dev` name is the "still cooking" signal.

## Acceptance
```
$ ./scripts/install.sh
installed: /home/coda/.local/bin/coda-dev (3f2c532-dirty)

$ /home/coda/.local/bin/coda-dev version
3f2c532-dirty
```
`go build ./... && go vet ./... && go test ./...` passes.

Closes #178