### PR TITLE
Core identity management — agent new scaffold + agent boot (#169)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,7 +103,7 @@ cmd/coda/              binary entrypoint and dispatcher (stdlib flag)
 internal/db/           SQLite open + numbered migrations
 internal/db/migrations numbered *.sql files, //go:embed, forward-only
 internal/session/      Agent, Session, Store, Provider interface, ULID IDs
-internal/identity/     (stub) PURPOSE.md / MEMORY.md / PROJECT.md
+internal/identity/     PURPOSE.md / MEMORY.md / PROJECT.md scaffold + boot
 internal/messages/     typed messaging primitives (send/recv/ack, routing)
 internal/orch/         (stub) orchestrator-specific logic
 internal/plugin/       (stub) plugin host, plugin.json, MCP server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,8 +115,10 @@ before inferring.
 
 ## Status
 
-v3 scaffold. Session, db, and messaging primitives are landed; identity
-/plugin/feature packages are still stubs. `coda agent new/ls/start/stop`
-and `coda send/recv/ack` are wired up.
+v3 scaffold. Session, db, identity, and messaging primitives are
+landed: `coda agent new` provisions identity dirs, `coda agent boot`
+emits a provider-ready JSON payload, `coda agent ls/start/stop` manage
+sessions, and `coda send/recv/ack` carries typed messages between
+agents. Plugin and feature packages are still stubs.
 
 Install: `./scripts/install.sh` (drops `coda-dev` in `$XDG_BIN_HOME`).

--- a/cmd/coda/main.go
+++ b/cmd/coda/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/evanstern/coda/internal/db"
+	"github.com/evanstern/coda/internal/identity"
 	"github.com/evanstern/coda/internal/messages"
 	"github.com/evanstern/coda/internal/session"
 )
@@ -67,6 +68,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "  version                          print the coda version\n")
 	fmt.Fprintf(w, "  agent new <name> [--provider p]  create a new agent\n")
 	fmt.Fprintf(w, "  agent ls                         list agents\n")
+	fmt.Fprintf(w, "  agent boot <name>                load identity for a provider\n")
 	fmt.Fprintf(w, "  agent start <name>               start an agent session\n")
 	fmt.Fprintf(w, "  agent stop <name> [--reason r]   stop the active session for an agent\n")
 	fmt.Fprintf(w, "  send <from> <to> <type> <body>   route a message\n")
@@ -84,6 +86,8 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 		return agentNew(args[1:], stdout, stderr)
 	case "ls":
 		return agentLs(args[1:], stdout, stderr)
+	case "boot":
+		return agentBoot(args[1:], stdout, stderr)
 	case "start":
 		return agentStart(args[1:], stdout, stderr)
 	case "stop":
@@ -142,6 +146,16 @@ func agentNew(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
 	}
+	root, err := identity.DefaultRoot()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	layout := identity.Resolve(root, name)
+	if err := identity.Scaffold(layout); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
 	ctx := context.Background()
 	conn, store, err := openStore(ctx)
 	if err != nil {
@@ -149,11 +163,53 @@ func agentNew(args []string, stdout, stderr io.Writer) int {
 		return exitUserErr
 	}
 	defer conn.Close()
-	if err := store.CreateAgent(ctx, session.Agent{Name: name, Provider: *provider}); err != nil {
+	if err := store.CreateAgent(ctx, session.Agent{Name: name, Provider: *provider, ConfigDir: layout.Root}); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
 	}
 	fmt.Fprintf(stdout, "created: %s\n", name)
+	return exitOK
+}
+
+func agentBoot(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent boot", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintf(stderr, "usage: coda agent boot <name>\n")
+		return exitUsage
+	}
+	name := fs.Arg(0)
+	ctx := context.Background()
+	conn, store, err := openStore(ctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	defer conn.Close()
+	agent, err := store.GetAgent(ctx, name)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	if agent.ConfigDir == "" {
+		fmt.Fprintf(stderr, "error: agent %q has no config_dir; run \"coda agent new %s\" to scaffold or set it manually\n", name, name)
+		return exitUserErr
+	}
+	layout := identity.LayoutAt(agent.ConfigDir)
+	payload, err := identity.Boot(agent.Name, layout)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	out, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	fmt.Fprintln(stdout, string(out))
 	return exitOK
 }
 

--- a/cmd/coda/main_test.go
+++ b/cmd/coda/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -58,6 +59,48 @@ func newTestStores(t *testing.T) (*session.Store, *messages.Store) {
 		t.Fatalf("migrate: %v", err)
 	}
 	return session.NewStore(d), messages.NewStore(d)
+}
+
+func TestAgentNewThenBoot(t *testing.T) {
+	state := t.TempDir()
+	config := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+	t.Setenv("XDG_CONFIG_HOME", config)
+
+	var stdout, stderr bytes.Buffer
+	if code := agentNew([]string{"ash"}, &stdout, &stderr); code != exitOK {
+		t.Fatalf("agent new: code=%d stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "created: ash") {
+		t.Fatalf("unexpected new stdout: %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := agentBoot([]string{"ash"}, &stdout, &stderr); code != exitOK {
+		t.Fatalf("agent boot: code=%d stderr=%q", code, stderr.String())
+	}
+	var got struct {
+		AgentName string            `json:"agent_name"`
+		ConfigDir string            `json:"config_dir"`
+		Files     []string          `json:"files"`
+		EnvVars   map[string]string `json:"env_vars"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode boot json: %v\nraw: %s", err, stdout.String())
+	}
+	if got.AgentName != "ash" {
+		t.Fatalf("agent_name=%q", got.AgentName)
+	}
+	if got.EnvVars["CODA_AGENT_NAME"] != "ash" {
+		t.Fatalf("env_vars=%v", got.EnvVars)
+	}
+	if !strings.HasPrefix(got.ConfigDir, config) {
+		t.Fatalf("config_dir %q not under %q", got.ConfigDir, config)
+	}
+	if len(got.Files) < 1 {
+		t.Fatalf("expected at least one file, got %v", got.Files)
+	}
 }
 
 func TestStartAgentNoProvider(t *testing.T) {

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -1,1 +1,248 @@
+// Package identity scaffolds and reads agent identity directories.
+//
+// Each agent owns a directory under $XDG_CONFIG_HOME/coda/agents/<name>
+// containing PURPOSE.md (role/scope/boundaries), MEMORY.md, PROJECT.md,
+// and per-day memory/ and learnings/ subdirectories. The personality
+// layer (SOUL.md, dreams) is the coda-soul plugin's territory; this
+// package is the core scaffolding only.
 package identity
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Layout describes the on-disk layout of an agent's identity dir.
+type Layout struct {
+	Root         string // ~/.config/coda/agents/<name>
+	PurposeMD    string // <Root>/PURPOSE.md
+	MemoryMD     string // <Root>/MEMORY.md
+	ProjectMD    string // <Root>/PROJECT.md
+	MemoryDir    string // <Root>/memory
+	LearningsDir string // <Root>/learnings
+}
+
+// DefaultRoot returns the base directory holding all identity dirs:
+// $XDG_CONFIG_HOME/coda/agents (default ~/.config/coda/agents).
+func DefaultRoot() (string, error) {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "coda", "agents"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home: %w", err)
+	}
+	return filepath.Join(home, ".config", "coda", "agents"), nil
+}
+
+// Resolve returns the Layout for an agent without touching disk.
+func Resolve(root, agentName string) Layout {
+	return LayoutAt(filepath.Join(root, agentName))
+}
+
+// LayoutAt returns the Layout rooted at the given absolute path. Use
+// this when you already have the agent's config_dir (e.g. from a DB
+// row) and don't want to split/rejoin it.
+func LayoutAt(root string) Layout {
+	return Layout{
+		Root:         root,
+		PurposeMD:    filepath.Join(root, "PURPOSE.md"),
+		MemoryMD:     filepath.Join(root, "MEMORY.md"),
+		ProjectMD:    filepath.Join(root, "PROJECT.md"),
+		MemoryDir:    filepath.Join(root, "memory"),
+		LearningsDir: filepath.Join(root, "learnings"),
+	}
+}
+
+const purposeTemplate = `# PURPOSE.md — {{.Name}}
+
+> The role, scope, and boundaries of this agent. Edit this file
+> to make the agent specific to its purpose.
+
+## Role
+
+(What is this agent's job?)
+
+## Scope
+
+(What does it own? What does it touch?)
+
+## Boundaries
+
+(What does it NOT do? When does it escalate? To whom?)
+`
+
+// Scaffold creates the layout on disk and writes the PURPOSE.md
+// template. Idempotent: re-running on an existing dir is a no-op
+// for files that already exist (does NOT overwrite).
+func Scaffold(layout Layout) error {
+	for _, d := range []string{layout.Root, layout.MemoryDir, layout.LearningsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", d, err)
+		}
+	}
+	name := filepath.Base(layout.Root)
+	purpose := strings.Replace(purposeTemplate, "{{.Name}}", name, 1)
+	if err := writeIfMissing(layout.PurposeMD, []byte(purpose)); err != nil {
+		return err
+	}
+	if err := writeIfMissing(layout.MemoryMD, nil); err != nil {
+		return err
+	}
+	if err := writeIfMissing(layout.ProjectMD, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeIfMissing(path string, content []byte) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// BootPayload is what `coda agent boot` produces: enough metadata
+// for a provider to deliver identity into a session.
+type BootPayload struct {
+	AgentName string            `json:"agent_name"`
+	ConfigDir string            `json:"config_dir"`
+	Files     []string          `json:"files"`
+	EnvVars   map[string]string `json:"env_vars"`
+}
+
+// Boot validates the on-disk layout and builds a BootPayload for the
+// given agent name. Returns an error if PURPOSE.md is missing (the
+// only required file). The agent name is used verbatim in the payload
+// and env vars; it is the caller's responsibility to pass the
+// authoritative name (e.g. from the DB row).
+func Boot(agentName string, layout Layout) (BootPayload, error) {
+	if _, err := os.Stat(layout.PurposeMD); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return BootPayload{}, fmt.Errorf("PURPOSE.md missing at %s", layout.PurposeMD)
+		}
+		return BootPayload{}, fmt.Errorf("stat purpose: %w", err)
+	}
+	files := []string{layout.PurposeMD}
+	for _, p := range []string{layout.MemoryMD, layout.ProjectMD} {
+		if _, err := os.Stat(p); err == nil {
+			files = append(files, p)
+		}
+	}
+	return BootPayload{
+		AgentName: agentName,
+		ConfigDir: layout.Root,
+		Files:     files,
+		EnvVars: map[string]string{
+			"CODA_AGENT_NAME":       agentName,
+			"CODA_AGENT_CONFIG_DIR": layout.Root,
+		},
+	}, nil
+}
+
+// AppendMemory appends a dated entry to memory/<YYYY-MM-DD>.md, creating
+// the file if needed. Date is UTC, format YYYY-MM-DD. The entry is
+// written verbatim with one trailing newline.
+func AppendMemory(layout Layout, when time.Time, entry string) error {
+	return appendDated(layout.MemoryDir, when, entry)
+}
+
+// AppendLearning appends to learnings/<YYYY-MM-DD>.md the same way.
+func AppendLearning(layout Layout, when time.Time, entry string) error {
+	return appendDated(layout.LearningsDir, when, entry)
+}
+
+func appendDated(dir string, when time.Time, entry string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	name := when.UTC().Format("2006-01-02") + ".md"
+	path := filepath.Join(dir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	if !strings.HasSuffix(entry, "\n") {
+		entry += "\n"
+	}
+	if _, err := f.WriteString(entry); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// MemoryEntry is one daily memory file.
+type MemoryEntry struct {
+	Date    time.Time
+	Path    string
+	Content string
+}
+
+// ReadRecentMemory returns the contents of the N most recent files in
+// memory/, ordered newest first. Files that fail to read are skipped
+// (not fatal).
+func ReadRecentMemory(layout Layout, n int) ([]MemoryEntry, error) {
+	return readRecent(layout.MemoryDir, n)
+}
+
+// ReadRecentLearnings is the same shape as ReadRecentMemory but for
+// learnings/.
+func ReadRecentLearnings(layout Layout, n int) ([]MemoryEntry, error) {
+	return readRecent(layout.LearningsDir, n)
+}
+
+func readRecent(dir string, n int) ([]MemoryEntry, error) {
+	if n <= 0 {
+		return nil, nil
+	}
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read dir %s: %w", dir, err)
+	}
+	type dated struct {
+		date time.Time
+		path string
+	}
+	var dates []dated
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		base := strings.TrimSuffix(e.Name(), ".md")
+		if base == e.Name() {
+			continue
+		}
+		t, err := time.ParseInLocation("2006-01-02", base, time.UTC)
+		if err != nil {
+			continue
+		}
+		dates = append(dates, dated{date: t, path: filepath.Join(dir, e.Name())})
+	}
+	sort.Slice(dates, func(i, j int) bool { return dates[i].date.After(dates[j].date) })
+	if len(dates) > n {
+		dates = dates[:n]
+	}
+	out := make([]MemoryEntry, 0, len(dates))
+	for _, d := range dates {
+		b, err := os.ReadFile(d.path)
+		if err != nil {
+			continue
+		}
+		out = append(out, MemoryEntry{Date: d.date, Path: d.path, Content: string(b)})
+	}
+	return out, nil
+}

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -1,0 +1,204 @@
+package identity
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScaffold_CreatesLayout(t *testing.T) {
+	root := t.TempDir()
+	layout := Resolve(root, "ash")
+	if err := Scaffold(layout); err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	for _, p := range []string{layout.PurposeMD, layout.MemoryMD, layout.ProjectMD} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected file %s: %v", p, err)
+		}
+	}
+	for _, d := range []string{layout.MemoryDir, layout.LearningsDir} {
+		st, err := os.Stat(d)
+		if err != nil {
+			t.Fatalf("expected dir %s: %v", d, err)
+		}
+		if !st.IsDir() {
+			t.Fatalf("%s is not a dir", d)
+		}
+	}
+	b, err := os.ReadFile(layout.PurposeMD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "PURPOSE.md — ash") {
+		t.Fatalf("PURPOSE.md missing template name: %q", string(b))
+	}
+	if !strings.Contains(string(b), "## Role") {
+		t.Fatalf("PURPOSE.md missing Role heading")
+	}
+	mem, err := os.ReadFile(layout.MemoryMD)
+	if err != nil {
+		t.Fatalf("read MEMORY.md: %v", err)
+	}
+	if len(mem) != 0 {
+		t.Fatalf("MEMORY.md should be empty, got %d bytes", len(mem))
+	}
+	proj, err := os.ReadFile(layout.ProjectMD)
+	if err != nil {
+		t.Fatalf("read PROJECT.md: %v", err)
+	}
+	if len(proj) != 0 {
+		t.Fatalf("PROJECT.md should be empty, got %d bytes", len(proj))
+	}
+}
+
+func TestScaffold_Idempotent(t *testing.T) {
+	root := t.TempDir()
+	layout := Resolve(root, "ash")
+	if err := Scaffold(layout); err != nil {
+		t.Fatal(err)
+	}
+	const custom = "# PURPOSE.md — ash\n\nUser-edited content.\n"
+	if err := os.WriteFile(layout.PurposeMD, []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Scaffold(layout); err != nil {
+		t.Fatalf("rerun scaffold: %v", err)
+	}
+	got, err := os.ReadFile(layout.PurposeMD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != custom {
+		t.Fatalf("Scaffold overwrote user edits.\nwant:\n%s\ngot:\n%s", custom, got)
+	}
+}
+
+func TestScaffold_PreservesUserEdits(t *testing.T) {
+	root := t.TempDir()
+	layout := Resolve(root, "ash")
+	if err := Scaffold(layout); err != nil {
+		t.Fatal(err)
+	}
+	const note = "user note\n"
+	if err := os.WriteFile(layout.MemoryMD, []byte(note), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Scaffold(layout); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(layout.MemoryMD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != note {
+		t.Fatalf("MEMORY.md was overwritten: got %q", got)
+	}
+}
+
+func TestBoot_RequiresPurpose(t *testing.T) {
+	root := t.TempDir()
+	layout := Resolve(root, "ash")
+	if err := Scaffold(layout); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(layout.PurposeMD); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Boot("ash", layout); err == nil {
+		t.Fatalf("expected error when PURPOSE.md missing")
+	}
+}
+
+func TestBoot_BuildsPayload(t *testing.T) {
+	root := t.TempDir()
+	layout := Resolve(root, "ash")
+	if err := Scaffold(layout); err != nil {
+		t.Fatal(err)
+	}
+	p, err := Boot("ash", layout)
+	if err != nil {
+		t.Fatalf("boot: %v", err)
+	}
+	if p.AgentName != "ash" {
+		t.Fatalf("AgentName=%q", p.AgentName)
+	}
+	if p.ConfigDir != layout.Root {
+		t.Fatalf("ConfigDir=%q want %q", p.ConfigDir, layout.Root)
+	}
+	if len(p.Files) != 3 {
+		t.Fatalf("expected 3 files (PURPOSE, MEMORY, PROJECT), got %v", p.Files)
+	}
+	if p.Files[0] != layout.PurposeMD {
+		t.Fatalf("first file should be PURPOSE.md, got %q", p.Files[0])
+	}
+	if p.EnvVars["CODA_AGENT_NAME"] != "ash" {
+		t.Fatalf("env CODA_AGENT_NAME=%q", p.EnvVars["CODA_AGENT_NAME"])
+	}
+	if p.EnvVars["CODA_AGENT_CONFIG_DIR"] != layout.Root {
+		t.Fatalf("env CODA_AGENT_CONFIG_DIR=%q want %q", p.EnvVars["CODA_AGENT_CONFIG_DIR"], layout.Root)
+	}
+}
+
+func TestAppendMemory(t *testing.T) {
+	root := t.TempDir()
+	layout := Resolve(root, "ash")
+	if err := Scaffold(layout); err != nil {
+		t.Fatal(err)
+	}
+	when := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	if err := AppendMemory(layout, when, "first entry"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendMemory(layout, when, "second entry\n"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(layout.MemoryDir, "2026-04-24.md")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if !strings.Contains(got, "first entry") || !strings.Contains(got, "second entry") {
+		t.Fatalf("missing entries in %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("file does not end with newline: %q", got)
+	}
+}
+
+func TestReadRecentMemory_OrderingAndLimit(t *testing.T) {
+	root := t.TempDir()
+	layout := Resolve(root, "ash")
+	if err := Scaffold(layout); err != nil {
+		t.Fatal(err)
+	}
+	dates := []time.Time{
+		time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC),
+	}
+	for _, d := range dates {
+		if err := AppendMemory(layout, d, "entry for "+d.Format("2006-01-02")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := ReadRecentMemory(layout, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	if !got[0].Date.Equal(dates[2]) {
+		t.Fatalf("first entry date=%v want %v", got[0].Date, dates[2])
+	}
+	if !got[1].Date.Equal(dates[1]) {
+		t.Fatalf("second entry date=%v want %v", got[1].Date, dates[1])
+	}
+	if !strings.Contains(got[0].Content, "2026-04-24") {
+		t.Fatalf("content mismatch: %q", got[0].Content)
+	}
+}


### PR DESCRIPTION
Core identity management — agent new scaffold + agent boot (#169)

Populate the internal/identity/ package and wire it into the agent
CLI. "agent new" now scaffolds an identity directory under
$XDG_CONFIG_HOME/coda/agents/<name>/ (PURPOSE.md template,
empty MEMORY.md and PROJECT.md, memory/ and learnings/ subdirs)
before inserting the DB row, and stores the path on the agent's
config_dir column. A new "agent boot" subcommand validates the
on-disk layout and emits a JSON BootPayload that providers can
consume (agent name, config dir, present files, env vars).

The package itself exposes Layout, Resolve, Scaffold, Boot,
AppendMemory/AppendLearning, and ReadRecentMemory/ReadRecentLearnings
with godoc on every exported symbol. Scaffold is idempotent —
re-running on an existing dir does not overwrite user edits to
PURPOSE.md, MEMORY.md, or PROJECT.md.

Tests cover layout creation, idempotency, user-edit preservation,
Boot's required PURPOSE.md, payload shape, dated append, and
recent-file ordering. A CLI integration test exercises
"agent new" → "agent boot" end-to-end with isolated XDG dirs.

Closes #169