### PR TITLE
Worktree lifecycle (#172)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,12 @@ before inferring.
 
 ## Status
 
-v3 scaffold. Session, db, identity, and messaging primitives are
-landed: `coda agent new` provisions identity dirs, `coda agent boot`
-emits a provider-ready JSON payload, `coda agent ls/start/stop` manage
-sessions, and `coda send/recv/ack` carries typed messages between
-agents. Plugin and feature packages are still stubs.
+v3 scaffold. Session, db, identity, messaging, and feature
+primitives are landed: `coda agent new` provisions identity dirs,
+`coda agent boot` emits a provider-ready JSON payload, `coda agent
+ls/start/stop` manage sessions, `coda send/recv/ack` carries typed
+messages between agents, and `coda feature start/finish/ls` manages
+git-worktree lifecycles with a local hook runner. The plugin host
+is still a stub.
 
 Install: `./scripts/install.sh` (drops `coda-dev` in `$XDG_BIN_HOME`).

--- a/cmd/coda/main.go
+++ b/cmd/coda/main.go
@@ -674,13 +674,9 @@ func featureLs(args []string, stdout, stderr io.Writer) int {
 		return exitUserErr
 	}
 	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "BRANCH\tBASE\tPATH")
+	fmt.Fprintln(tw, "BRANCH\tPATH")
 	for _, w := range wts {
-		base := w.Base
-		if base == "" {
-			base = "-"
-		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\n", w.Branch, base, w.Path)
+		fmt.Fprintf(tw, "%s\t%s\n", w.Branch, w.Path)
 	}
 	if err := tw.Flush(); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)

--- a/cmd/coda/main.go
+++ b/cmd/coda/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/evanstern/coda/internal/db"
+	"github.com/evanstern/coda/internal/feature"
 	"github.com/evanstern/coda/internal/identity"
 	"github.com/evanstern/coda/internal/messages"
 	"github.com/evanstern/coda/internal/session"
@@ -52,6 +53,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return runRecv(args[1:], stdout, stderr)
 	case "ack":
 		return runAck(args[1:], stdout, stderr)
+	case "feature":
+		return runFeature(args[1:], stdout, stderr)
 	case "-h", "--help", "help":
 		printUsage(stdout)
 		return exitOK
@@ -74,6 +77,9 @@ func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "  send <from> <to> <type> <body>   route a message\n")
 	fmt.Fprintf(w, "  recv <agent>                     list unacked messages for agent\n")
 	fmt.Fprintf(w, "  ack <id>                         mark a message acknowledged\n")
+	fmt.Fprintf(w, "  feature start <branch>           create a worktree from the default or given base branch\n")
+	fmt.Fprintf(w, "  feature finish <branch>          remove a worktree and delete its branch\n")
+	fmt.Fprintf(w, "  feature ls                       list active feature worktrees\n")
 }
 
 func runAgent(args []string, stdout, stderr io.Writer) int {
@@ -571,4 +577,122 @@ func bodyPreview(body []byte) string {
 		s = s[:maxLen]
 	}
 	return s
+}
+
+func runFeature(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintf(stderr, "usage: coda feature <subcommand>\n")
+		return exitUsage
+	}
+	switch args[0] {
+	case "start":
+		return featureStart(args[1:], stdout, stderr)
+	case "finish":
+		return featureFinish(args[1:], stdout, stderr)
+	case "ls":
+		return featureLs(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown feature subcommand: %s\n", args[0])
+		return exitUsage
+	}
+}
+
+func featureStart(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("feature start", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	base := fs.String("base", "", "base branch to fork from (default: detect)")
+	project := fs.String("project", "", "project name (default: detect from cwd)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintf(stderr, "usage: coda feature start <branch> [--base <branch>] [--project <name>]\n")
+		return exitUsage
+	}
+	branch := fs.Arg(0)
+	proj, err := resolveFeatureProject(*project)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	runner := feature.NewLocalHookRunner("", stderr)
+	wt, err := feature.Start(context.Background(), proj, branch, *base, runner)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	fmt.Fprintf(stdout, "created: %s at %s\n", wt.Branch, wt.Path)
+	return exitOK
+}
+
+func featureFinish(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("feature finish", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	project := fs.String("project", "", "project name (default: detect from cwd)")
+	force := fs.Bool("force", false, "discard uncommitted changes")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintf(stderr, "usage: coda feature finish <branch> [--project <name>] [--force]\n")
+		return exitUsage
+	}
+	branch := fs.Arg(0)
+	proj, err := resolveFeatureProject(*project)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	runner := feature.NewLocalHookRunner("", stderr)
+	if err := feature.Finish(context.Background(), proj, branch, *force, runner); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	fmt.Fprintf(stdout, "removed: %s\n", branch)
+	return exitOK
+}
+
+func featureLs(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("feature ls", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	project := fs.String("project", "", "project name (default: detect from cwd)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "usage: coda feature ls [--project <name>]\n")
+		return exitUsage
+	}
+	proj, err := resolveFeatureProject(*project)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	wts, err := feature.List(context.Background(), proj)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "BRANCH\tBASE\tPATH")
+	for _, w := range wts {
+		base := w.Base
+		if base == "" {
+			base = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", w.Branch, base, w.Path)
+	}
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	return exitOK
+}
+
+func resolveFeatureProject(name string) (*feature.Project, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("getwd: %w", err)
+	}
+	return feature.FindProject(cwd, name)
 }

--- a/cmd/coda/main_test.go
+++ b/cmd/coda/main_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -413,5 +416,111 @@ func TestRecv_JSONBodyNotBase64(t *testing.T) {
 	}
 	if body.Text != "hello" {
 		t.Fatalf("body.text=%q want %q", body.Text, "hello")
+	}
+}
+
+func makeFeatureTestProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	bare := filepath.Join(root, ".bare")
+	gitMust(t, root, "init", "--bare", "--initial-branch=main", ".bare")
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: ./.bare\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitMust(t, bare, "symbolic-ref", "HEAD", "refs/heads/main")
+	gitMust(t, root, "worktree", "add", filepath.Join(root, "main"))
+	mainWT := filepath.Join(root, "main")
+	gitMust(t, mainWT, "config", "user.email", "test@example.com")
+	gitMust(t, mainWT, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(mainWT, "README.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitMust(t, mainWT, "add", "README.md")
+	gitMust(t, mainWT, "commit", "-m", "init")
+	return root
+}
+
+func gitMust(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func TestFeature_StartLsFinish_RoundTrip(t *testing.T) {
+	root := makeFeatureTestProject(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(root, "main")); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"feature", "start", "feat-x"}, &stdout, &stderr); code != exitOK {
+		t.Fatalf("feature start: code=%d stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "created: feat-x at ") {
+		t.Fatalf("unexpected start stdout: %q", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "feat-x")); err != nil {
+		t.Fatalf("worktree not created: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := run([]string{"feature", "ls"}, &stdout, &stderr); code != exitOK {
+		t.Fatalf("feature ls: code=%d stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "feat-x") {
+		t.Fatalf("ls missing feat-x: %q", out)
+	}
+	if strings.Contains(out, " main ") || strings.Contains(out, "\tmain\t") {
+		t.Fatalf("ls should exclude main worktree: %q", out)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := run([]string{"feature", "finish", "feat-x"}, &stdout, &stderr); code != exitOK {
+		t.Fatalf("feature finish: code=%d stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "removed: feat-x") {
+		t.Fatalf("unexpected finish stdout: %q", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "feat-x")); !os.IsNotExist(err) {
+		t.Fatalf("worktree path still exists: %v", err)
+	}
+}
+
+func TestFeature_FinishUncommittedNoForce(t *testing.T) {
+	root := makeFeatureTestProject(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(root, "main")); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"feature", "start", "dirty"}, &stdout, &stderr); code != exitOK {
+		t.Fatalf("start: %d %q", code, stderr.String())
+	}
+	if err := os.WriteFile(filepath.Join(root, "dirty", "scratch.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := run([]string{"feature", "finish", "dirty"}, &stdout, &stderr); code != exitUserErr {
+		t.Fatalf("expected exitUserErr, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "uncommitted") {
+		t.Fatalf("expected uncommitted error: %q", stderr.String())
 	}
 }

--- a/docs/specs/172-worktree-lifecycle.md
+++ b/docs/specs/172-worktree-lifecycle.md
@@ -1,0 +1,271 @@
+# Spec #172 — Worktree lifecycle (`coda feature start/finish/ls`)
+
+**Status:** drafted 2026-04-27, implemented in this PR.
+**Milestone:** [#166](https://github.com/users/evanstern/projects) coda v3 Go CLI
+**Card:** focus #172
+**Implements:** primitive 5 of 5
+
+## Vision
+
+`coda feature start/finish/ls` — git-worktrees as the isolation
+primitive for parallel feature work. Provider-agnostic (no tmux,
+no attach, no session creation). Runs hooks at four lifecycle
+boundaries.
+
+Reference: v2 `lib/feature.sh` (~316 lines bash, mostly tmux-attach
+logic that's NOT in v3 scope). v3 inherits the worktree mechanics
+but drops the session/tmux coupling.
+
+## Architectural decisions
+
+These are **answered**. Don't relitigate during implementation.
+
+- **Project resolution: cwd-walk (v2-compatible).** Walk up from
+  cwd looking for `.bare/` + `.git` text-file pattern. Override
+  via `--project <name>` flag (resolves to
+  `$PROJECTS_DIR/<name>/`).
+- **Worktree path: `<project_root>/<branch>/`.** Same as v2.
+  Branch names with slashes (`feature/foo`) work as-is — git
+  accepts them.
+- **Hook implementation: minimal local runner.** This card ships
+  its own hook runner that scans
+  `$XDG_CONFIG_HOME/coda/hooks/<event>/` and runs sorted scripts
+  with env vars. #171 will REPLACE this runner with the full
+  plugin-aware version. Design the hook-call site so #171's
+  replacement is a one-line wire change.
+- **No tmux/attach/session integration.** v2's
+  `_coda_feature_start` ends in `tmux attach`. v3's just creates
+  the worktree and fires hooks. Session creation is a separate
+  concern (would happen via `coda agent start` if at all).
+- **No PR creation.** `coda feature start` doesn't run
+  `gh pr create`. That's a separate workflow.
+
+## Scope
+
+### 1. Project resolution (`internal/feature/project.go`)
+
+```go
+type Project struct {
+    Name string
+    Root string  // absolute path to bare-repo project root
+}
+
+// FindProject resolves a project from cwd or by explicit name.
+// nameHint == "" -> walk up from cwd looking for .bare/ + .git
+// nameHint != "" -> resolve PROJECTS_DIR/<nameHint>/ (must exist)
+func FindProject(cwd, nameHint string) (*Project, error)
+```
+
+Error cases:
+- `nameHint` set but `PROJECTS_DIR/<name>` doesn't exist or isn't
+  a coda project (no `.bare/`)
+- `nameHint` empty, cwd-walk reaches root without finding a
+  project
+- Found dir but `.git` text-file doesn't point at `./.bare`
+
+`PROJECTS_DIR` env var with default `$HOME/projects`.
+
+### 2. Worktree operations (`internal/feature/worktree.go`)
+
+```go
+type Worktree struct {
+    Branch string  // raw branch name (may contain /)
+    Path   string  // absolute worktree dir
+    Base   string  // base branch the worktree was forked from
+}
+
+// Start creates a new worktree at <project.Root>/<branch>/ from <base>.
+// If base is empty, detects the project's default branch.
+// Errors if branch already exists or worktree path is occupied.
+func Start(project *Project, branch, base string) (*Worktree, error)
+
+// Finish removes the worktree and (optionally) deletes the branch.
+// Refuses if worktree has uncommitted changes unless force=true.
+func Finish(project *Project, branch string, force bool) error
+
+// List returns active worktrees, excluding the bare repo's main worktree.
+func List(project *Project) ([]Worktree, error)
+```
+
+**Default branch detection:** look at
+`origin/HEAD -> refs/remotes/origin/<name>` (via
+`git symbolic-ref refs/remotes/origin/HEAD`). Fallback: `main`,
+then `master`. Same as v2's `_coda_detect_default_branch`.
+
+**git invocation:** use `git -C <project.Root> worktree add ...`,
+not bare-shell. Capture stderr on failure for the user-facing
+error.
+
+### 3. Hook runner (minimal, replaceable)
+
+```go
+// internal/feature/hooks.go (REPLACED when #171 lands)
+type HookRunner interface {
+    Run(ctx context.Context, event string, env map[string]string) error
+}
+
+type localHookRunner struct {
+    dir string  // $XDG_CONFIG_HOME/coda/hooks/
+}
+
+// Run executes hooks for an event:
+//  1. Read $h.dir/<event>/
+//  2. List entries; filter to executable regular files
+//  3. Sort by LC_ALL=C filename order
+//  4. exec.Command each, pipe env, run; warn-on-failure to stderr
+//  5. Return nil even if some failed (warn-only contract)
+func (h *localHookRunner) Run(ctx context.Context, event string, env map[string]string) error
+```
+
+`feature.Start/Finish` take a `HookRunner` parameter.
+`cmd/coda/main.go` constructs `localHookRunner` for v3.0; #171
+will swap in `plugin.HookRunner`.
+
+**Hook events fired:**
+- `pre-feature-create` — before `git worktree add` runs
+- `post-feature-create` — after worktree exists, before return
+- `pre-feature-teardown` — before `git worktree remove`
+- `post-feature-finish` — after teardown completes
+
+**Env vars (match v2 names exactly):**
+- `CODA_PROJECT_NAME`
+- `CODA_PROJECT_DIR` (= project.Root)
+- `CODA_FEATURE_BRANCH` (= raw branch name)
+- `CODA_WORKTREE_DIR` (= worktree.Path)
+
+These are exported to the hook subprocess via `os.Environ` plus
+overrides. v2 plugins port cleanly when they read these.
+
+### 4. CLI surface (`cmd/coda/main.go`)
+
+New top-level subcommand `feature`:
+
+```
+coda feature start <branch> [--base <branch>] [--project <name>]
+coda feature finish <branch> [--project <name>] [--force]
+coda feature ls [--project <name>]
+```
+
+Output:
+
+| Subcommand | stdout | exit |
+|---|---|---|
+| `feature start` | `created: <branch> at <path>` | 0 |
+| `feature finish` | `removed: <branch>` | 0 |
+| `feature finish` (uncommitted, no `--force`) | error to stderr | 1 |
+| `feature ls` | tabwriter `BRANCH\tBASE\tPATH` | 0 |
+
+Stick to stdlib `flag`. Each subcommand is a `flag.FlagSet`
+parsed in a `switch`. No cobra.
+
+## Repo layout (new files)
+
+```
+internal/feature/
+  feature.go      (currently stub — replace; or add files alongside)
+  project.go      Project, FindProject
+  project_test.go
+  worktree.go     Worktree, Start, Finish, List
+  worktree_test.go
+  hooks.go        HookRunner interface + localHookRunner
+  hooks_test.go
+docs/specs/
+  172-worktree-lifecycle.md   (this doc)
+```
+
+`cmd/coda/main.go`: new `feature` top-level subcommand wired
+into the `run()` switch.
+
+## Test surface
+
+**Unit tests:**
+
+- `FindProject`:
+  - cwd inside project
+  - cwd outside (error)
+  - nameHint set, exists
+  - nameHint set, missing dir (error)
+  - nameHint set, dir without `.bare` (error)
+- `Start`:
+  - clean case
+  - branch already exists (error)
+  - worktree path occupied (error)
+  - default-branch detection
+- `Finish`:
+  - clean case
+  - uncommitted changes + force=false (error)
+  - uncommitted changes + force=true (succeeds)
+  - nonexistent branch (error)
+- `List`:
+  - empty project
+  - project with worktrees (output excludes bare/main worktree)
+- `localHookRunner.Run`:
+  - empty event dir
+  - sort order respected
+  - env-var passthrough
+  - non-executable files skipped
+  - failure → warn to stderr but don't abort
+
+**Integration tests:**
+
+- End-to-end: build a fake bare-repo project in `t.TempDir()`
+  (init bare + check out main worktree), call
+  `feature.Start("foo")`, assert worktree exists at right path,
+  then `feature.Finish` and assert removed.
+- Hook firing: drop a script in user hooks dir, call
+  `feature.Start`, assert script ran with right env vars.
+- CLI E2E (in `cmd/coda/main_test.go`):
+  `coda feature start/finish` through `run()`.
+
+**git fixture helper:** `internal/feature/testutil.go` (or
+similar) with `NewTestProject(t)` that initializes a bare repo +
+default branch in `t.TempDir()`. Use real `git` calls — git is
+a hard runtime dep already, no need to mock it.
+
+## Acceptance gate
+
+```bash
+cd <worktree>
+go build ./...
+go vet ./...
+go test ./... -count=1 -race
+```
+
+All three must exit 0.
+
+## Out of scope
+
+- tmux/attach/session integration. v2's feature_start ends in
+  attach; v3 doesn't.
+- PR creation via `gh pr create`.
+- Project lifecycle (`coda project start/clone/close`) — separate
+  card if/when needed.
+- Plugin hooks. #171's job. THIS card uses a local-only runner.
+- Backward compat with v2 `coda feature start` shell command —
+  v3 binary is independent.
+- Don't touch `internal/identity/`, `internal/messages/`,
+  `internal/session/`.
+- Don't update CLI usage strings (#185).
+- Don't fix the harness FEATURE SESSION preamble (#188) — strip
+  it from this PR's AGENTS.md as part of normal hygiene.
+
+## Done when
+
+- `coda feature start/finish/ls` work end-to-end against a real
+  git project
+- Four hook events fire with v2-compatible env vars
+- `localHookRunner` is replaceable (HookRunner interface) so #171
+  can swap it in cleanly
+- Acceptance gate exits 0
+- AGENTS.md updated to reflect feature lifecycle shipping
+- This spec doc committed at `docs/specs/172-worktree-lifecycle.md`
+- PR opened against main
+
+## Coordination
+
+- **Lands first.** #171 will replace `internal/feature/hooks.go`
+  with calls into `internal/plugin/HookRunner`. The interface in
+  this card is the seam.
+- **Unblocks:** orchestrator workflow (creating feature sessions
+  for spawn agents) — including this orchestrator's own work.
+- **Sequenced before #171** to keep #171's scope manageable.

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -1,1 +1,0 @@
-package feature

--- a/internal/feature/hooks.go
+++ b/internal/feature/hooks.go
@@ -1,0 +1,131 @@
+package feature
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// HookRunner runs lifecycle hook scripts for a named event. The
+// localHookRunner in this package scans the user's hook directory.
+// #171 will replace this with a plugin-aware implementation; the
+// interface keeps the call sites stable.
+type HookRunner interface {
+	Run(ctx context.Context, event string, env HookEnv) error
+}
+
+// localHookRunner runs scripts from $XDG_CONFIG_HOME/coda/hooks/<event>/.
+// Failures are warnings: the runner logs to stderr and continues.
+type localHookRunner struct {
+	dir    string
+	stderr io.Writer
+}
+
+// NewLocalHookRunner returns a HookRunner that reads hook scripts from
+// the given hooks directory. If hooksDir is empty, it defaults to
+// $XDG_CONFIG_HOME/coda/hooks (or $HOME/.config/coda/hooks).
+func NewLocalHookRunner(hooksDir string, stderr io.Writer) HookRunner {
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	if hooksDir == "" {
+		hooksDir = defaultHooksDir()
+	}
+	return &localHookRunner{dir: hooksDir, stderr: stderr}
+}
+
+func defaultHooksDir() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "coda", "hooks")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "coda", "hooks")
+}
+
+// Run executes every executable regular file under <dir>/<event>/ in
+// sorted filename order, with env merged into os.Environ. Per the
+// warn-only contract, Run always returns nil; failures are logged.
+func (h *localHookRunner) Run(ctx context.Context, event string, env HookEnv) error {
+	if h.dir == "" {
+		return nil
+	}
+	eventDir := filepath.Join(h.dir, event)
+	entries, err := os.ReadDir(eventDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		fmt.Fprintf(h.stderr, "warn: read hooks dir %s: %v\n", eventDir, err)
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+
+	merged := mergedEnv(env)
+
+	for _, name := range names {
+		path := filepath.Join(eventDir, name)
+		info, err := os.Lstat(path)
+		if err != nil {
+			fmt.Fprintf(h.stderr, "warn: lstat hook %s: %v\n", path, err)
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			continue
+		}
+		cmd := exec.CommandContext(ctx, path)
+		cmd.Env = merged
+		cmd.Stdout = h.stderr
+		cmd.Stderr = h.stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(h.stderr, "warn: hook %s/%s failed: %v\n", event, name, err)
+		}
+	}
+	return nil
+}
+
+func mergedEnv(env HookEnv) []string {
+	base := os.Environ()
+	if len(env) == 0 {
+		return base
+	}
+	overrides := make(map[string]string, len(env))
+	for k, v := range env {
+		overrides[k] = v
+	}
+	out := make([]string, 0, len(base)+len(overrides))
+	for _, kv := range base {
+		key := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			key = kv[:i]
+		}
+		if _, override := overrides[key]; override {
+			continue
+		}
+		out = append(out, kv)
+	}
+	keys := make([]string, 0, len(overrides))
+	for k := range overrides {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		out = append(out, k+"="+overrides[k])
+	}
+	return out
+}

--- a/internal/feature/hooks_test.go
+++ b/internal/feature/hooks_test.go
@@ -1,0 +1,125 @@
+package feature
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocalHookRunner_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	var stderr bytes.Buffer
+	r := NewLocalHookRunner(dir, &stderr)
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestLocalHookRunner_SortOrder(t *testing.T) {
+	dir := t.TempDir()
+	eventDir := filepath.Join(dir, "pre-feature-create")
+	if err := os.MkdirAll(eventDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(t.TempDir(), "log.txt")
+	for _, name := range []string{"30-c", "10-a", "20-b"} {
+		script := "#!/bin/sh\necho " + name + " >> " + output + "\n"
+		if err := os.WriteFile(filepath.Join(eventDir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r := NewLocalHookRunner(dir, &bytes.Buffer{})
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "10-a\n20-b\n30-c\n"
+	if string(got) != want {
+		t.Fatalf("order=%q want %q", got, want)
+	}
+}
+
+func TestLocalHookRunner_EnvPassthrough(t *testing.T) {
+	dir := t.TempDir()
+	eventDir := filepath.Join(dir, "post-feature-create")
+	if err := os.MkdirAll(eventDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(t.TempDir(), "env.txt")
+	script := "#!/bin/sh\nprintf '%s|%s|%s|%s\\n' \"$CODA_PROJECT_NAME\" \"$CODA_PROJECT_DIR\" \"$CODA_FEATURE_BRANCH\" \"$CODA_WORKTREE_DIR\" > " + output + "\n"
+	if err := os.WriteFile(filepath.Join(eventDir, "10-env"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := NewLocalHookRunner(dir, &bytes.Buffer{})
+	env := HookEnv{
+		"CODA_PROJECT_NAME":   "demo",
+		"CODA_PROJECT_DIR":    "/tmp/demo",
+		"CODA_FEATURE_BRANCH": "feat-x",
+		"CODA_WORKTREE_DIR":   "/tmp/demo/feat-x",
+	}
+	if err := r.Run(context.Background(), "post-feature-create", env); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "demo|/tmp/demo|feat-x|/tmp/demo/feat-x\n"
+	if string(got) != want {
+		t.Fatalf("env=%q want %q", got, want)
+	}
+}
+
+func TestLocalHookRunner_NonExecutableSkipped(t *testing.T) {
+	dir := t.TempDir()
+	eventDir := filepath.Join(dir, "pre-feature-create")
+	if err := os.MkdirAll(eventDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(t.TempDir(), "out.txt")
+	if err := os.WriteFile(filepath.Join(eventDir, "10-skip"), []byte("#!/bin/sh\necho skip > "+output+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := NewLocalHookRunner(dir, &bytes.Buffer{})
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(output); !os.IsNotExist(err) {
+		t.Fatalf("non-executable hook ran: %v", err)
+	}
+}
+
+func TestLocalHookRunner_FailureWarnsButContinues(t *testing.T) {
+	dir := t.TempDir()
+	eventDir := filepath.Join(dir, "pre-feature-create")
+	if err := os.MkdirAll(eventDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(t.TempDir(), "ran.txt")
+	if err := os.WriteFile(filepath.Join(eventDir, "10-fail"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(eventDir, "20-ok"), []byte("#!/bin/sh\necho ran > "+output+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	r := NewLocalHookRunner(dir, &stderr)
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatalf("Run should warn-only: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "warn:") {
+		t.Fatalf("expected warning in stderr: %q", stderr.String())
+	}
+	if got, err := os.ReadFile(output); err != nil || string(got) != "ran\n" {
+		t.Fatalf("subsequent hook didn't run: out=%q err=%v", got, err)
+	}
+}

--- a/internal/feature/project.go
+++ b/internal/feature/project.go
@@ -1,0 +1,128 @@
+// Package feature implements the v3 worktree lifecycle: project
+// resolution, worktree start/finish/list, and a local hook runner.
+package feature
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Project identifies a coda project on disk. The project layout is
+// the v2-compatible bare-repo pattern:
+//
+//	<Root>/
+//	  .bare/        # bare git repository
+//	  .git          # text file: "gitdir: ./.bare"
+//	  <branch>/     # one directory per checked-out worktree
+type Project struct {
+	Name string
+	Root string // absolute path to the project root (parent of .bare/)
+}
+
+// FindProject resolves a project from cwd or by explicit name.
+//
+// nameHint == "": walk up from cwd looking for the .bare/ + .git
+// text-file layout. Errors at filesystem root if none found.
+//
+// nameHint != "": resolve PROJECTS_DIR/<nameHint>/ (default
+// $HOME/projects). The directory must exist and contain .bare/.
+func FindProject(cwd, nameHint string) (*Project, error) {
+	if nameHint != "" {
+		return findByName(nameHint)
+	}
+	return findFromCwd(cwd)
+}
+
+func findByName(name string) (*Project, error) {
+	base := os.Getenv("PROJECTS_DIR")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve projects dir: %w", err)
+		}
+		base = filepath.Join(home, "projects")
+	}
+	root := filepath.Join(base, name)
+	info, err := os.Stat(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("project %q not found at %s", name, root)
+		}
+		return nil, fmt.Errorf("stat project: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("project path %s is not a directory", root)
+	}
+	if err := validateProjectDir(root); err != nil {
+		return nil, err
+	}
+	return &Project{Name: name, Root: root}, nil
+}
+
+func findFromCwd(cwd string) (*Project, error) {
+	if cwd == "" {
+		return nil, fmt.Errorf("cwd is empty")
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("absolute cwd: %w", err)
+	}
+	dir := abs
+	for {
+		if err := validateProjectDir(dir); err == nil {
+			return &Project{Name: filepath.Base(dir), Root: dir}, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil, fmt.Errorf("no coda project found above %s", abs)
+		}
+		dir = parent
+	}
+}
+
+// validateProjectDir checks that dir has the bare-repo project layout:
+// a .bare/ directory and a .git text-file pointing at ./.bare.
+func validateProjectDir(dir string) error {
+	bare := filepath.Join(dir, ".bare")
+	info, err := os.Stat(bare)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("%s: missing .bare directory", dir)
+	}
+	gitFile := filepath.Join(dir, ".git")
+	contents, err := os.ReadFile(gitFile)
+	if err != nil {
+		return fmt.Errorf("%s: missing .git text-file", dir)
+	}
+	body := strings.TrimSpace(string(contents))
+	// Accept either "gitdir: ./.bare" or "gitdir: .bare" or absolute
+	// gitdir pointing at <dir>/.bare.
+	if !strings.HasPrefix(body, "gitdir:") {
+		return fmt.Errorf("%s: .git is not a gitdir pointer", dir)
+	}
+	target := strings.TrimSpace(strings.TrimPrefix(body, "gitdir:"))
+	if !pointsAtBare(dir, target) {
+		return fmt.Errorf("%s: .git does not point at ./.bare (got %q)", dir, target)
+	}
+	return nil
+}
+
+// pointsAtBare returns true if target (the value after "gitdir:")
+// resolves to <dir>/.bare. target may be relative or absolute.
+func pointsAtBare(dir, target string) bool {
+	resolved := target
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(dir, target)
+	}
+	a, err := filepath.Abs(resolved)
+	if err != nil {
+		return false
+	}
+	b, err := filepath.Abs(filepath.Join(dir, ".bare"))
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}

--- a/internal/feature/project.go
+++ b/internal/feature/project.go
@@ -88,13 +88,22 @@ func findFromCwd(cwd string) (*Project, error) {
 func validateProjectDir(dir string) error {
 	bare := filepath.Join(dir, ".bare")
 	info, err := os.Stat(bare)
-	if err != nil || !info.IsDir() {
-		return fmt.Errorf("%s: missing .bare directory", dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s: missing .bare directory", dir)
+		}
+		return fmt.Errorf("%s: stat .bare: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s: .bare is not a directory", dir)
 	}
 	gitFile := filepath.Join(dir, ".git")
 	contents, err := os.ReadFile(gitFile)
 	if err != nil {
-		return fmt.Errorf("%s: missing .git text-file", dir)
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s: missing .git text-file", dir)
+		}
+		return fmt.Errorf("%s: read .git: %w", dir, err)
 	}
 	body := strings.TrimSpace(string(contents))
 	// Accept either "gitdir: ./.bare" or "gitdir: .bare" or absolute

--- a/internal/feature/project_test.go
+++ b/internal/feature/project_test.go
@@ -1,0 +1,76 @@
+package feature
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFindProject_CwdInsideProject(t *testing.T) {
+	p := newTestProject(t)
+	subdir := filepath.Join(p.Root, "main", "deep", "nested")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := FindProject(subdir, "")
+	if err != nil {
+		t.Fatalf("FindProject: %v", err)
+	}
+	if got.Root != p.Root {
+		t.Fatalf("Root=%q want %q", got.Root, p.Root)
+	}
+	if got.Name != filepath.Base(p.Root) {
+		t.Fatalf("Name=%q want %q", got.Name, filepath.Base(p.Root))
+	}
+}
+
+func TestFindProject_CwdOutsideProject(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := FindProject(dir, ""); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestFindProject_NameHintExists(t *testing.T) {
+	p := newTestProject(t)
+	parent := filepath.Dir(p.Root)
+	t.Setenv("PROJECTS_DIR", parent)
+	got, err := FindProject("/", filepath.Base(p.Root))
+	if err != nil {
+		t.Fatalf("FindProject: %v", err)
+	}
+	if got.Name != filepath.Base(p.Root) {
+		t.Fatalf("Name=%q", got.Name)
+	}
+	if got.Root != p.Root {
+		t.Fatalf("Root=%q want %q", got.Root, p.Root)
+	}
+}
+
+func TestFindProject_NameHintMissing(t *testing.T) {
+	t.Setenv("PROJECTS_DIR", t.TempDir())
+	_, err := FindProject("/", "nope")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFindProject_NameHintNotACodaProject(t *testing.T) {
+	projects := t.TempDir()
+	bad := filepath.Join(projects, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PROJECTS_DIR", projects)
+	_, err := FindProject("/", "bad")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), ".bare") {
+		t.Fatalf("expected .bare error, got: %v", err)
+	}
+}

--- a/internal/feature/testutil_test.go
+++ b/internal/feature/testutil_test.go
@@ -1,0 +1,42 @@
+package feature
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func newTestProject(t *testing.T) *Project {
+	t.Helper()
+	root := t.TempDir()
+	bare := filepath.Join(root, ".bare")
+	mustGit(t, root, "init", "--bare", "--initial-branch=main", ".bare")
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: ./.bare\n"), 0o644); err != nil {
+		t.Fatalf("write .git: %v", err)
+	}
+	mustGit(t, bare, "symbolic-ref", "HEAD", "refs/heads/main")
+	mustGit(t, root, "worktree", "add", filepath.Join(root, "main"))
+
+	mainWT := filepath.Join(root, "main")
+	mustGit(t, mainWT, "config", "user.email", "test@example.com")
+	mustGit(t, mainWT, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(mainWT, "README.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mustGit(t, mainWT, "add", "README.md")
+	mustGit(t, mainWT, "commit", "-m", "init")
+
+	return &Project{Name: filepath.Base(root), Root: root}
+}
+
+func mustGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}

--- a/internal/feature/worktree.go
+++ b/internal/feature/worktree.go
@@ -25,10 +25,10 @@ type HookEnv = map[string]string
 
 // Hook event names. v2-compatible.
 const (
-	EventPreCreate    = "pre-feature-create"
-	EventPostCreate   = "post-feature-create"
-	EventPreTeardown  = "pre-feature-teardown"
-	EventPostTeardown = "post-feature-finish"
+	EventPreCreate   = "pre-feature-create"
+	EventPostCreate  = "post-feature-create"
+	EventPreTeardown = "pre-feature-teardown"
+	EventPostFinish  = "post-feature-finish"
 )
 
 // Start creates a new worktree at <project.Root>/<branch>/ from base.
@@ -133,13 +133,14 @@ func Finish(ctx context.Context, project *Project, branch string, force bool, ru
 	}
 
 	if runner != nil {
-		_ = runner.Run(ctx, EventPostTeardown, env)
+		_ = runner.Run(ctx, EventPostFinish, env)
 	}
 	return nil
 }
 
 // List returns active feature worktrees, excluding the bare repo's
 // internal worktree and the project's default-branch worktree.
+// Detached worktrees (no branch ref) are also skipped.
 func List(ctx context.Context, project *Project) ([]Worktree, error) {
 	if project == nil {
 		return nil, errors.New("project is nil")
@@ -148,6 +149,10 @@ func List(ctx context.Context, project *Project) ([]Worktree, error) {
 	if err != nil {
 		return nil, fmt.Errorf("git worktree list: %w: %s", err, strings.TrimSpace(out))
 	}
+	// Default-branch detection is best-effort here: some projects (e.g.
+	// freshly inited bare repo with no remote and no branches) won't have
+	// one yet. If we can't resolve it, skip the default-path filter
+	// rather than fail the whole listing.
 	defaultBranch, _ := detectDefaultBranch(ctx, project.Root)
 	defaultPath := ""
 	if defaultBranch != "" {
@@ -155,14 +160,20 @@ func List(ctx context.Context, project *Project) ([]Worktree, error) {
 	}
 	barePath := filepath.Clean(filepath.Join(project.Root, ".bare"))
 
-	entries := parseWorktreeList(out)
+	entries, err := parseWorktreeList(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse worktree list: %w", err)
+	}
 	result := make([]Worktree, 0, len(entries))
 	for _, e := range entries {
-		clean := filepath.Clean(e.path)
-		if clean == barePath || clean == defaultPath {
+		if e.bare || e.detached {
 			continue
 		}
-		if e.bare {
+		if e.branch == "" {
+			continue
+		}
+		clean := filepath.Clean(e.path)
+		if clean == barePath || (defaultPath != "" && clean == defaultPath) {
 			continue
 		}
 		result = append(result, Worktree{Branch: e.branch, Path: clean})
@@ -171,15 +182,16 @@ func List(ctx context.Context, project *Project) ([]Worktree, error) {
 }
 
 type worktreeEntry struct {
-	path   string
-	branch string
-	bare   bool
+	path     string
+	branch   string
+	bare     bool
+	detached bool
 }
 
 // parseWorktreeList parses the output of `git worktree list --porcelain`.
 // Blocks are separated by blank lines; each block has lines like
 // "worktree <path>", "HEAD <sha>", "branch <ref>", "bare", "detached".
-func parseWorktreeList(s string) []worktreeEntry {
+func parseWorktreeList(s string) ([]worktreeEntry, error) {
 	var entries []worktreeEntry
 	var cur worktreeEntry
 	flush := func() {
@@ -189,6 +201,7 @@ func parseWorktreeList(s string) []worktreeEntry {
 		cur = worktreeEntry{}
 	}
 	scanner := bufio.NewScanner(strings.NewReader(s))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" {
@@ -203,10 +216,15 @@ func parseWorktreeList(s string) []worktreeEntry {
 			cur.branch = strings.TrimPrefix(ref, "refs/heads/")
 		case line == "bare":
 			cur.bare = true
+		case line == "detached":
+			cur.detached = true
 		}
 	}
 	flush()
-	return entries
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
 }
 
 // detectDefaultBranch resolves origin/HEAD or falls back to main, then master.

--- a/internal/feature/worktree.go
+++ b/internal/feature/worktree.go
@@ -1,0 +1,239 @@
+package feature
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Worktree describes a single feature worktree on disk.
+type Worktree struct {
+	Branch string
+	Path   string
+	Base   string
+}
+
+// HookEnv is the v2-compatible env-var set passed to hook scripts. Keep
+// the keys in sync with v2 plugin contracts.
+type HookEnv = map[string]string
+
+// Hook event names. v2-compatible.
+const (
+	EventPreCreate    = "pre-feature-create"
+	EventPostCreate   = "post-feature-create"
+	EventPreTeardown  = "pre-feature-teardown"
+	EventPostTeardown = "post-feature-finish"
+)
+
+// Start creates a new worktree at <project.Root>/<branch>/ from base.
+// If base == "", the project's default branch is detected. Hooks fire
+// at pre-feature-create and post-feature-create.
+func Start(ctx context.Context, project *Project, branch, base string, runner HookRunner) (*Worktree, error) {
+	if project == nil {
+		return nil, errors.New("project is nil")
+	}
+	if branch == "" {
+		return nil, errors.New("branch is required")
+	}
+	worktreePath := filepath.Join(project.Root, branch)
+
+	if _, err := os.Stat(worktreePath); err == nil {
+		return nil, fmt.Errorf("worktree path already exists: %s", worktreePath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("stat worktree path: %w", err)
+	}
+
+	if base == "" {
+		detected, err := detectDefaultBranch(ctx, project.Root)
+		if err != nil {
+			return nil, err
+		}
+		base = detected
+	}
+
+	env := HookEnv{
+		"CODA_PROJECT_NAME":   project.Name,
+		"CODA_PROJECT_DIR":    project.Root,
+		"CODA_FEATURE_BRANCH": branch,
+		"CODA_WORKTREE_DIR":   worktreePath,
+	}
+
+	if runner != nil {
+		_ = runner.Run(ctx, EventPreCreate, env)
+	}
+
+	out, err := runGit(ctx, project.Root, "worktree", "add", "-b", branch, worktreePath, base)
+	if err != nil {
+		return nil, fmt.Errorf("git worktree add: %w: %s", err, strings.TrimSpace(out))
+	}
+
+	wt := &Worktree{Branch: branch, Path: worktreePath, Base: base}
+
+	if runner != nil {
+		_ = runner.Run(ctx, EventPostCreate, env)
+	}
+	return wt, nil
+}
+
+// Finish removes the worktree for branch and deletes the branch.
+// Refuses if the worktree has uncommitted changes unless force is true.
+// Hooks fire at pre-feature-teardown and post-feature-finish.
+func Finish(ctx context.Context, project *Project, branch string, force bool, runner HookRunner) error {
+	if project == nil {
+		return errors.New("project is nil")
+	}
+	if branch == "" {
+		return errors.New("branch is required")
+	}
+	worktreePath := filepath.Join(project.Root, branch)
+
+	if _, err := os.Stat(worktreePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("worktree does not exist: %s", worktreePath)
+		}
+		return fmt.Errorf("stat worktree path: %w", err)
+	}
+
+	status, err := runGit(ctx, worktreePath, "status", "--porcelain")
+	if err != nil {
+		return fmt.Errorf("git status: %w: %s", err, strings.TrimSpace(status))
+	}
+	if strings.TrimSpace(status) != "" && !force {
+		return fmt.Errorf("worktree %s has uncommitted changes; pass --force to discard", worktreePath)
+	}
+
+	env := HookEnv{
+		"CODA_PROJECT_NAME":   project.Name,
+		"CODA_PROJECT_DIR":    project.Root,
+		"CODA_FEATURE_BRANCH": branch,
+		"CODA_WORKTREE_DIR":   worktreePath,
+	}
+
+	if runner != nil {
+		_ = runner.Run(ctx, EventPreTeardown, env)
+	}
+
+	args := []string{"worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, worktreePath)
+	if out, err := runGit(ctx, project.Root, args...); err != nil {
+		return fmt.Errorf("git worktree remove: %w: %s", err, strings.TrimSpace(out))
+	}
+
+	if out, err := runGit(ctx, project.Root, "branch", "-D", branch); err != nil {
+		return fmt.Errorf("git branch -D: %w: %s", err, strings.TrimSpace(out))
+	}
+
+	if runner != nil {
+		_ = runner.Run(ctx, EventPostTeardown, env)
+	}
+	return nil
+}
+
+// List returns active feature worktrees, excluding the bare repo's
+// internal worktree and the project's default-branch worktree.
+func List(ctx context.Context, project *Project) ([]Worktree, error) {
+	if project == nil {
+		return nil, errors.New("project is nil")
+	}
+	out, err := runGit(ctx, project.Root, "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, fmt.Errorf("git worktree list: %w: %s", err, strings.TrimSpace(out))
+	}
+	defaultBranch, _ := detectDefaultBranch(ctx, project.Root)
+	defaultPath := ""
+	if defaultBranch != "" {
+		defaultPath = filepath.Clean(filepath.Join(project.Root, defaultBranch))
+	}
+	barePath := filepath.Clean(filepath.Join(project.Root, ".bare"))
+
+	entries := parseWorktreeList(out)
+	result := make([]Worktree, 0, len(entries))
+	for _, e := range entries {
+		clean := filepath.Clean(e.path)
+		if clean == barePath || clean == defaultPath {
+			continue
+		}
+		if e.bare {
+			continue
+		}
+		result = append(result, Worktree{Branch: e.branch, Path: clean})
+	}
+	return result, nil
+}
+
+type worktreeEntry struct {
+	path   string
+	branch string
+	bare   bool
+}
+
+// parseWorktreeList parses the output of `git worktree list --porcelain`.
+// Blocks are separated by blank lines; each block has lines like
+// "worktree <path>", "HEAD <sha>", "branch <ref>", "bare", "detached".
+func parseWorktreeList(s string) []worktreeEntry {
+	var entries []worktreeEntry
+	var cur worktreeEntry
+	flush := func() {
+		if cur.path != "" {
+			entries = append(entries, cur)
+		}
+		cur = worktreeEntry{}
+	}
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			flush()
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			cur.path = strings.TrimPrefix(line, "worktree ")
+		case strings.HasPrefix(line, "branch "):
+			ref := strings.TrimPrefix(line, "branch ")
+			cur.branch = strings.TrimPrefix(ref, "refs/heads/")
+		case line == "bare":
+			cur.bare = true
+		}
+	}
+	flush()
+	return entries
+}
+
+// detectDefaultBranch resolves origin/HEAD or falls back to main, then master.
+func detectDefaultBranch(ctx context.Context, gitDir string) (string, error) {
+	out, err := runGit(ctx, gitDir, "symbolic-ref", "refs/remotes/origin/HEAD")
+	if err == nil {
+		ref := strings.TrimSpace(out)
+		name := strings.TrimPrefix(ref, "refs/remotes/origin/")
+		if name != "" {
+			return name, nil
+		}
+	}
+	for _, candidate := range []string{"main", "master"} {
+		if _, err := runGit(ctx, gitDir, "show-ref", "--verify", "--quiet", "refs/heads/"+candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("could not detect default branch in %s", gitDir)
+}
+
+// runGit invokes git -C dir with args and returns combined stdout+stderr.
+func runGit(ctx context.Context, dir string, args ...string) (string, error) {
+	full := append([]string{"-C", dir}, args...)
+	cmd := exec.CommandContext(ctx, "git", full...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}

--- a/internal/feature/worktree_test.go
+++ b/internal/feature/worktree_test.go
@@ -156,3 +156,28 @@ func TestList_WithWorktreesExcludesMain(t *testing.T) {
 		t.Fatalf("expected alpha+beta, got %+v", wts)
 	}
 }
+
+func TestParseWorktreeList_DetachedSkippedByList(t *testing.T) {
+	p := newTestProject(t)
+	mustGit(t, p.Root, "worktree", "add", "--detach", filepath.Join(p.Root, "detached-wt"), "main")
+	if _, err := Start(context.Background(), p, "branched", "main", nil); err != nil {
+		t.Fatal(err)
+	}
+	wts, err := List(context.Background(), p)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(wts) != 1 || wts[0].Branch != "branched" {
+		t.Fatalf("expected only branched, got %+v", wts)
+	}
+}
+
+func TestParseWorktreeList_ReturnsErrorOnNoData(t *testing.T) {
+	entries, err := parseWorktreeList("")
+	if err != nil {
+		t.Fatalf("parse empty: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %+v", entries)
+	}
+}

--- a/internal/feature/worktree_test.go
+++ b/internal/feature/worktree_test.go
@@ -1,0 +1,158 @@
+package feature
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStart_Clean(t *testing.T) {
+	p := newTestProject(t)
+	wt, err := Start(context.Background(), p, "feat-x", "main", nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if wt.Branch != "feat-x" {
+		t.Fatalf("Branch=%q", wt.Branch)
+	}
+	if wt.Path != filepath.Join(p.Root, "feat-x") {
+		t.Fatalf("Path=%q", wt.Path)
+	}
+	if wt.Base != "main" {
+		t.Fatalf("Base=%q", wt.Base)
+	}
+	if _, err := os.Stat(wt.Path); err != nil {
+		t.Fatalf("worktree path missing: %v", err)
+	}
+}
+
+func TestStart_BranchAlreadyExists(t *testing.T) {
+	p := newTestProject(t)
+	if _, err := Start(context.Background(), p, "dup", "main", nil); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(p.Root, "dup")); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, p.Root, "worktree", "prune")
+	_, err := Start(context.Background(), p, "dup", "main", nil)
+	if err == nil {
+		t.Fatalf("expected error when branch already exists")
+	}
+}
+
+func TestStart_PathOccupied(t *testing.T) {
+	p := newTestProject(t)
+	occupied := filepath.Join(p.Root, "feat-occupied")
+	if err := os.MkdirAll(occupied, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Start(context.Background(), p, "feat-occupied", "main", nil); err == nil {
+		t.Fatalf("expected error when path occupied")
+	}
+}
+
+func TestStart_DefaultBranchDetection(t *testing.T) {
+	p := newTestProject(t)
+	wt, err := Start(context.Background(), p, "feat-default", "", nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if wt.Base != "main" {
+		t.Fatalf("Base=%q want main", wt.Base)
+	}
+}
+
+func TestFinish_Clean(t *testing.T) {
+	p := newTestProject(t)
+	wt, err := Start(context.Background(), p, "feat-fin", "main", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Finish(context.Background(), p, "feat-fin", false, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if _, err := os.Stat(wt.Path); !os.IsNotExist(err) {
+		t.Fatalf("worktree path still present: %v", err)
+	}
+}
+
+func TestFinish_UncommittedNoForce(t *testing.T) {
+	p := newTestProject(t)
+	wt, err := Start(context.Background(), p, "feat-dirty", "main", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.Path, "scratch.txt"), []byte("dirty"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = Finish(context.Background(), p, "feat-dirty", false, nil)
+	if err == nil {
+		t.Fatalf("expected error for uncommitted changes")
+	}
+	if !strings.Contains(err.Error(), "uncommitted") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFinish_UncommittedForce(t *testing.T) {
+	p := newTestProject(t)
+	wt, err := Start(context.Background(), p, "feat-force", "main", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.Path, "scratch.txt"), []byte("dirty"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Finish(context.Background(), p, "feat-force", true, nil); err != nil {
+		t.Fatalf("Finish --force: %v", err)
+	}
+	if _, err := os.Stat(wt.Path); !os.IsNotExist(err) {
+		t.Fatalf("worktree path still present: %v", err)
+	}
+}
+
+func TestFinish_Nonexistent(t *testing.T) {
+	p := newTestProject(t)
+	err := Finish(context.Background(), p, "ghost", false, nil)
+	if err == nil {
+		t.Fatalf("expected error for nonexistent worktree")
+	}
+}
+
+func TestList_Empty(t *testing.T) {
+	p := newTestProject(t)
+	wts, err := List(context.Background(), p)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(wts) != 0 {
+		t.Fatalf("expected 0 worktrees, got %d: %+v", len(wts), wts)
+	}
+}
+
+func TestList_WithWorktreesExcludesMain(t *testing.T) {
+	p := newTestProject(t)
+	if _, err := Start(context.Background(), p, "alpha", "main", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Start(context.Background(), p, "beta", "main", nil); err != nil {
+		t.Fatal(err)
+	}
+	wts, err := List(context.Background(), p)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(wts) != 2 {
+		t.Fatalf("expected 2 worktrees, got %d: %+v", len(wts), wts)
+	}
+	branches := map[string]bool{}
+	for _, w := range wts {
+		branches[w.Branch] = true
+	}
+	if !branches["alpha"] || !branches["beta"] {
+		t.Fatalf("expected alpha+beta, got %+v", wts)
+	}
+}


### PR DESCRIPTION
Implements v3 primitive #5: `coda feature start/finish/ls`.

Spec: docs/specs/172-worktree-lifecycle.md (in this PR)

## What ships
- internal/feature/{project,worktree,hooks}.go
- coda feature start/finish/ls subcommands
- Local hook runner (HookRunner interface — replaceable by #171)
- Four hook events fire with v2-compatible CODA_* env vars

## Tests
- Unit tests for project resolution, worktree ops, hook runner
- Integration tests against real git in t.TempDir()
- CLI E2E in cmd/coda/main_test.go

## Acceptance gate
go build ./... && go vet ./... && go test ./... -count=1 -race  ✓

## Out of scope (per spec)
- No tmux/attach (v2 had this; v3 doesn't)
- No PR creation
- No plugin hooks (that's #171; this card's runner is replaceable)
- No project lifecycle (separate card)

Closes #172
Refs #166 milestone (v3 Go CLI), #171 (next).