### PR TITLE
Plugin host (#171)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,12 +73,14 @@ before inferring.
 
 ## Status
 
-v3 scaffold. Session, db, identity, messaging, and feature
-primitives are landed: `coda agent new` provisions identity dirs,
-`coda agent boot` emits a provider-ready JSON payload, `coda agent
-ls/start/stop` manage sessions, `coda send/recv/ack` carries typed
-messages between agents, and `coda feature start/finish/ls` manages
-git-worktree lifecycles with a local hook runner. The plugin host
-is still a stub.
+v3 scaffold. All five core primitives have landed: `coda agent new`
+provisions identity dirs, `coda agent boot` emits a provider-ready
+JSON payload, `coda agent ls/start/stop` manage sessions, `coda
+send/recv/ack` carries typed messages between agents, `coda feature
+start/finish/ls` manages git-worktree lifecycles, and the plugin
+host loads `plugin.json` manifests, registers subprocess providers
+into the `ProviderRegistry`, layers user and plugin hooks, dispatches
+plugin-contributed CLI commands, and exposes plugin tools through
+`coda mcp serve` (stdio JSON-RPC 2.0).
 
 Install: `./scripts/install.sh` (drops `coda-dev` in `$XDG_BIN_HOME`).

--- a/cmd/coda/main.go
+++ b/cmd/coda/main.go
@@ -383,7 +383,7 @@ func agentStart(args []string, stdout, stderr io.Writer) int {
 	}
 	defer conn.Close()
 
-	return startAgent(ctx, store, msgStore, defaultRegistry(), name, stdout, stderr)
+	return startAgent(ctx, store, msgStore, defaultRegistry(ctx), name, stdout, stderr)
 }
 
 func agentStop(args []string, stdout, stderr io.Writer) int {
@@ -405,24 +405,27 @@ func agentStop(args []string, stdout, stderr io.Writer) int {
 		return exitUserErr
 	}
 	defer conn.Close()
-	return stopAgent(ctx, store, defaultRegistry(), name, *reason, stdout, stderr)
+	return stopAgent(ctx, store, defaultRegistry(ctx), name, *reason, stdout, stderr)
 }
 
 // defaultRegistry returns the process-wide provider registry,
 // populated from plugins discovered under the default plugins
-// directory. Failures during plugin load are written to stderr but
-// never abort startup; an empty registry is still useful (the user
-// just gets "no provider registered" at agent start time).
-func defaultRegistry() *session.ProviderRegistry {
+// directory. Each registered SubprocessProvider is bound to ctx so
+// CLI cancellation propagates to plugin subprocesses. Failures
+// during plugin load are written to stderr but never abort startup;
+// an empty registry is still useful (the user just gets "no
+// provider registered" at agent start time).
+func defaultRegistry(ctx context.Context) *session.ProviderRegistry {
 	reg := session.NewProviderRegistry()
-	plugins, err := plugin.NewLoader("", os.Stderr).Load(context.Background())
+	plugins, err := plugin.NewLoader("", os.Stderr).Load(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warn: load plugins: %v\n", err)
 		return reg
 	}
 	for _, pl := range plugins {
 		for name, spec := range pl.Manifest.Provides.Providers {
-			reg.Register(name, plugin.NewSubprocessProvider(name, pl.Root, spec.Exec))
+			p := plugin.NewSubprocessProvider(name, pl.Root, spec.Exec).WithContext(ctx)
+			reg.Register(name, p)
 		}
 	}
 	return reg
@@ -430,8 +433,8 @@ func defaultRegistry() *session.ProviderRegistry {
 
 // loadPluginsForHooks loads plugins for hook dispatch. Errors warn to
 // stderr; a partial set is still useful.
-func loadPluginsForHooks(stderr io.Writer) []plugin.Plugin {
-	plugins, err := plugin.NewLoader("", stderr).Load(context.Background())
+func loadPluginsForHooks(ctx context.Context, stderr io.Writer) []plugin.Plugin {
+	plugins, err := plugin.NewLoader("", stderr).Load(ctx)
 	if err != nil {
 		fmt.Fprintf(stderr, "warn: load plugins: %v\n", err)
 		return nil
@@ -538,7 +541,7 @@ func runSend(args []string, stdout, stderr io.Writer) int {
 		return exitUserErr
 	}
 	defer conn.Close()
-	router := messages.NewRouter(msgStore, store, defaultRegistry())
+	router := messages.NewRouter(msgStore, store, defaultRegistry(ctx))
 	id, delivered, err := router.Send(ctx, from, to, t, []byte(body))
 	if err != nil {
 		if id == 0 {
@@ -740,8 +743,9 @@ func featureStart(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
 	}
-	runner := plugin.NewHookRunner("", loadPluginsForHooks(stderr), stderr)
-	wt, err := feature.Start(context.Background(), proj, branch, *base, runner)
+	ctx := context.Background()
+	runner := plugin.NewHookRunner("", loadPluginsForHooks(ctx, stderr), stderr)
+	wt, err := feature.Start(ctx, proj, branch, *base, runner)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
@@ -768,8 +772,9 @@ func featureFinish(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
 	}
-	runner := plugin.NewHookRunner("", loadPluginsForHooks(stderr), stderr)
-	if err := feature.Finish(context.Background(), proj, branch, *force, runner); err != nil {
+	ctx := context.Background()
+	runner := plugin.NewHookRunner("", loadPluginsForHooks(ctx, stderr), stderr)
+	if err := feature.Finish(ctx, proj, branch, *force, runner); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
 	}

--- a/cmd/coda/main.go
+++ b/cmd/coda/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/evanstern/coda/internal/feature"
 	"github.com/evanstern/coda/internal/identity"
 	"github.com/evanstern/coda/internal/messages"
+	"github.com/evanstern/coda/internal/plugin"
 	"github.com/evanstern/coda/internal/session"
 )
 
@@ -55,14 +56,111 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return runAck(args[1:], stdout, stderr)
 	case "feature":
 		return runFeature(args[1:], stdout, stderr)
+	case "mcp":
+		return runMCP(args[1:], stdout, stderr)
 	case "-h", "--help", "help":
 		printUsage(stdout)
 		return exitOK
 	default:
-		fmt.Fprintf(stderr, "unknown command: %s\n", args[0])
-		printUsage(stderr)
+		return runPluginCommand(args, stdout, stderr)
+	}
+}
+
+func runPluginCommand(args []string, stdout, stderr io.Writer) int {
+	plugins, err := plugin.NewLoader("", stderr).Load(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "warn: load plugins: %v\n", err)
+	}
+	registry, err := plugin.BuildCommandRegistry(plugins)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	if _, ok := registry.Lookup(args[0]); ok {
+		return registry.Dispatch(context.Background(), args[0], args[1:], os.Stdin, stdout, stderr)
+	}
+	fmt.Fprintf(stderr, "unknown command: %s\n", args[0])
+	printUsage(stderr)
+	return exitUsage
+}
+
+func runMCP(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintf(stderr, "usage: coda mcp <serve|tools>\n")
 		return exitUsage
 	}
+	switch args[0] {
+	case "serve":
+		return mcpServe(args[1:], stdout, stderr)
+	case "tools":
+		return mcpTools(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown mcp subcommand: %s\n", args[0])
+		return exitUsage
+	}
+}
+
+func loadMCPServer(stderr io.Writer) (*plugin.MCPServer, error) {
+	plugins, err := plugin.NewLoader("", stderr).Load(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return plugin.NewMCPServer(plugins)
+}
+
+func mcpServe(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("mcp serve", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "usage: coda mcp serve\n")
+		return exitUsage
+	}
+	srv, err := loadMCPServer(stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	if err := srv.Serve(context.Background(), os.Stdin, stdout); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	return exitOK
+}
+
+func mcpTools(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("mcp tools", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "emit JSON instead of table")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	srv, err := loadMCPServer(stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	if *asJSON {
+		out, err := json.MarshalIndent(srv.Tools, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "error: %v\n", err)
+			return exitUserErr
+		}
+		fmt.Fprintln(stdout, string(out))
+		return exitOK
+	}
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tPLUGIN\tDESCRIPTION")
+	for _, t := range srv.Tools {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", t.Name, t.Plugin, t.Description)
+	}
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUserErr
+	}
+	return exitOK
 }
 
 func printUsage(w io.Writer) {
@@ -80,6 +178,8 @@ func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "  feature start <branch>           create a worktree from the default or given base branch\n")
 	fmt.Fprintf(w, "  feature finish <branch>          remove a worktree and delete its branch\n")
 	fmt.Fprintf(w, "  feature ls                       list active feature worktrees\n")
+	fmt.Fprintf(w, "  mcp serve                        run the stdio MCP server (plugin tools)\n")
+	fmt.Fprintf(w, "  mcp tools                        list registered MCP tools\n")
 }
 
 func runAgent(args []string, stdout, stderr io.Writer) int {
@@ -308,10 +408,35 @@ func agentStop(args []string, stdout, stderr io.Writer) int {
 	return stopAgent(ctx, store, defaultRegistry(), name, *reason, stdout, stderr)
 }
 
-// defaultRegistry returns the process-wide provider registry. Empty
-// in this PR; later cards will populate it from plugins.
+// defaultRegistry returns the process-wide provider registry,
+// populated from plugins discovered under the default plugins
+// directory. Failures during plugin load are written to stderr but
+// never abort startup; an empty registry is still useful (the user
+// just gets "no provider registered" at agent start time).
 func defaultRegistry() *session.ProviderRegistry {
-	return session.NewProviderRegistry()
+	reg := session.NewProviderRegistry()
+	plugins, err := plugin.NewLoader("", os.Stderr).Load(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warn: load plugins: %v\n", err)
+		return reg
+	}
+	for _, pl := range plugins {
+		for name, spec := range pl.Manifest.Provides.Providers {
+			reg.Register(name, plugin.NewSubprocessProvider(name, pl.Root, spec.Exec))
+		}
+	}
+	return reg
+}
+
+// loadPluginsForHooks loads plugins for hook dispatch. Errors warn to
+// stderr; a partial set is still useful.
+func loadPluginsForHooks(stderr io.Writer) []plugin.Plugin {
+	plugins, err := plugin.NewLoader("", stderr).Load(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "warn: load plugins: %v\n", err)
+		return nil
+	}
+	return plugins
 }
 
 func startAgent(ctx context.Context, store *session.Store, msgStore *messages.Store, reg *session.ProviderRegistry, name string, stdout, stderr io.Writer) int {
@@ -615,7 +740,7 @@ func featureStart(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
 	}
-	runner := feature.NewLocalHookRunner("", stderr)
+	runner := plugin.NewHookRunner("", loadPluginsForHooks(stderr), stderr)
 	wt, err := feature.Start(context.Background(), proj, branch, *base, runner)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
@@ -643,7 +768,7 @@ func featureFinish(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
 	}
-	runner := feature.NewLocalHookRunner("", stderr)
+	runner := plugin.NewHookRunner("", loadPluginsForHooks(stderr), stderr)
 	if err := feature.Finish(context.Background(), proj, branch, *force, runner); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr

--- a/cmd/coda/main_test.go
+++ b/cmd/coda/main_test.go
@@ -497,6 +497,86 @@ func TestFeature_StartLsFinish_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestMCP_ServeRoundTrip(t *testing.T) {
+	pluginsDir := t.TempDir()
+	pluginRoot := filepath.Join(pluginsDir, "demo")
+	if err := os.MkdirAll(filepath.Join(pluginRoot, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+  "name": "demo",
+  "version": "0.1.0",
+  "coda": "^0.1.0",
+  "provides": {
+    "mcp_tools": {
+      "echo": {"description": "echo back stdin", "command": ["bin/echo"]}
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(pluginRoot, "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, "bin", "echo"), []byte("#!/bin/sh\ncat\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODA_PLUGINS_DIR", pluginsDir)
+
+	stdinPipeR, stdinPipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prevStdin := os.Stdin
+	os.Stdin = stdinPipeR
+	t.Cleanup(func() { os.Stdin = prevStdin })
+
+	go func() {
+		_, _ = stdinPipeW.WriteString(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n")
+		_ = stdinPipeW.Close()
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"mcp", "serve"}, &stdout, &stderr); code != exitOK {
+		t.Fatalf("mcp serve: code=%d stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"echo"`) {
+		t.Fatalf("expected echo tool in stdout: %q", stdout.String())
+	}
+	var resp struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v\n%s", err, stdout.String())
+	}
+	if len(resp.Result.Tools) != 1 || resp.Result.Tools[0].Name != "echo" {
+		t.Fatalf("tools=%+v", resp.Result.Tools)
+	}
+}
+
+func TestMCP_ToolsCommand(t *testing.T) {
+	pluginsDir := t.TempDir()
+	pluginRoot := filepath.Join(pluginsDir, "demo")
+	if err := os.MkdirAll(pluginRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"name":"demo","version":"0.1.0","coda":"^0.1.0","provides":{"mcp_tools":{"echo":{"description":"e","command":["true"]}}}}`
+	if err := os.WriteFile(filepath.Join(pluginRoot, "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODA_PLUGINS_DIR", pluginsDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"mcp", "tools"}, &stdout, &stderr); code != exitOK {
+		t.Fatalf("mcp tools: code=%d stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "echo") || !strings.Contains(stdout.String(), "demo") {
+		t.Fatalf("missing tool/plugin: %q", stdout.String())
+	}
+}
+
 func TestFeature_FinishUncommittedNoForce(t *testing.T) {
 	root := makeFeatureTestProject(t)
 	cwd, err := os.Getwd()

--- a/docs/plugin-contracts/hooks.md
+++ b/docs/plugin-contracts/hooks.md
@@ -1,0 +1,59 @@
+# Hook contract
+
+Hooks are executable scripts that fire at lifecycle events. The
+runner discovers hooks from two layers:
+
+1. **User layer** — `$XDG_CONFIG_HOME/coda/hooks/<event>/`
+2. **Plugin layer** — for each loaded plugin, either
+   - the manifest-declared `provides.hooks.<event>` glob patterns
+     (resolved relative to the plugin root), or
+   - if no manifest entry, `<plugin-root>/hooks/<event>/`
+
+Within each layer, the runner sorts entries by `LC_ALL=C` filename
+and invokes them in order. Layers run user → plugin so user hooks
+get a first crack.
+
+## Events
+
+Coda v3 fires hooks at four feature-lifecycle events:
+
+| event                  | when                                                     |
+|------------------------|----------------------------------------------------------|
+| `pre-feature-create`   | before `git worktree add` for a new feature              |
+| `post-feature-create`  | after the worktree is on disk                            |
+| `pre-feature-teardown` | before tearing down a worktree (after dirty-state check) |
+| `post-feature-finish`  | after worktree removal and branch deletion               |
+
+## Environment
+
+The runner merges these v2-compatible environment variables into the
+hook process environment:
+
+| variable               | value                                  |
+|------------------------|----------------------------------------|
+| `CODA_PROJECT_NAME`    | resolved project name                  |
+| `CODA_PROJECT_DIR`     | absolute path to the project root      |
+| `CODA_FEATURE_BRANCH`  | the branch being created or finished   |
+| `CODA_WORKTREE_DIR`    | absolute path to the worktree on disk  |
+
+`os.Environ()` is also passed through; any matching keys in the
+hook env override the parent's.
+
+## Failure model
+
+Hooks are warn-only: a non-zero exit logs `warn: hook <event>/<name>
+failed: <err>` to stderr and the runner continues with subsequent
+hooks. Non-executable regular files in the hook dir are silently
+skipped.
+
+## Authoring
+
+A hook is any executable file. Shebangs work:
+
+```sh
+#!/bin/sh
+echo "creating ${CODA_FEATURE_BRANCH} for ${CODA_PROJECT_NAME}"
+```
+
+Make it executable (`chmod +x`) and drop it into the appropriate
+directory.

--- a/docs/plugin-contracts/mcp.md
+++ b/docs/plugin-contracts/mcp.md
@@ -1,0 +1,87 @@
+# MCP tool contract
+
+`coda mcp serve` runs a stdio JSON-RPC 2.0 server that exposes
+plugin-declared tools through the Model Context Protocol. The server
+implements three methods:
+
+- `initialize` — returns server capabilities and protocol version
+- `tools/list` — returns the registered tools
+- `tools/call` — dispatches to a plugin's command, with JSON
+  arguments on stdin and stdout returned as text content
+
+Notifications (no `id`) are accepted and ignored. Other methods
+return a JSON-RPC `-32601 method not found` error.
+
+## Tool registration
+
+In a plugin's `plugin.json`:
+
+```json
+{
+  "provides": {
+    "mcp_tools": {
+      "echo": {
+        "description": "echo back its input",
+        "inputSchema": {"type": "object"},
+        "command": ["bin/echo"]
+      }
+    }
+  }
+}
+```
+
+`command` is the argv used to invoke the tool. The first element is
+resolved relative to the plugin root if it is not absolute.
+Subsequent elements are passed as additional arguments verbatim.
+
+## Invocation flow
+
+When a client sends:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}
+```
+
+The server:
+
+1. Looks up the tool by name. Unknown tool → `-32602 invalid params`.
+2. Spawns the tool process with the manifest's `command` argv.
+3. Writes the `arguments` JSON object to the tool's stdin.
+4. Captures stdout. On success, returns
+   `{"content":[{"type":"text","text":"<stdout>"}],"isError":false}`.
+5. On non-zero exit, returns the same shape with `"isError":true`
+   and the error text in the content.
+
+## Wire format
+
+Newline-delimited JSON. One JSON object per line on stdin and
+stdout. Other framings (HTTP, content-length-prefixed) are out of
+scope for this card.
+
+## Server identity
+
+`initialize` returns:
+
+```json
+{
+  "protocolVersion": "2024-11-05",
+  "capabilities": {"tools": {}},
+  "serverInfo": {"name": "coda", "version": "0.1.0"}
+}
+```
+
+## Standard error codes
+
+| code     | meaning                                             |
+|----------|-----------------------------------------------------|
+| `-32700` | parse error (malformed JSON on the wire)           |
+| `-32600` | invalid request (jsonrpc field missing or wrong)   |
+| `-32601` | method not found                                   |
+| `-32602` | invalid params (missing `name`, unknown tool, …)   |
+| `-32603` | internal server error                              |
+
+## Out of scope
+
+The card ships only the three methods above. Prompts, resources,
+sampling, completion, logging, and other MCP methods are
+follow-ups.

--- a/docs/plugin-contracts/plugins.md
+++ b/docs/plugin-contracts/plugins.md
@@ -1,0 +1,78 @@
+# Plugin manifest (`plugin.json`)
+
+A coda v3 plugin is a directory under
+`$XDG_CONFIG_HOME/coda/plugins/<name>/` (overridable via
+`$CODA_PLUGINS_DIR`) containing a `plugin.json` manifest plus any
+executable artifacts the manifest references.
+
+The host loads every immediate subdirectory of the plugins dir; a
+malformed manifest is logged as a warning and the plugin is skipped
+without aborting the load.
+
+## Schema
+
+```json
+{
+  "name":        "coda-codaclaw",
+  "version":     "0.1.0",
+  "coda":        "^0.1.0",
+  "description": "CodaClaw provider plugin",
+  "provides": {
+    "commands":  { "<name>": { "description": "...", "exec": "bin/cmd-<name>" } },
+    "hooks":     { "<event>": ["hooks/<event>/*"] },
+    "providers": { "<name>": { "exec": "bin/provider-<name>" } },
+    "mcp_tools": { "<tool>": { "description": "...", "inputSchema": {...}, "command": ["bin/tool", "arg"] } }
+  },
+  "dependencies": { "system": ["..."], "go": "1.22", "npm": [] },
+  "install": "scripts/install.sh"
+}
+```
+
+## Required fields
+
+| field     | type   | notes                                          |
+|-----------|--------|------------------------------------------------|
+| `name`    | string | identifier; used in error messages and logs   |
+| `version` | string | plugin version; informational                 |
+| `coda`    | string | semver range against host (warn-only for now) |
+
+A missing or empty required field aborts the manifest with a
+descriptive error. Unknown top-level keys log a warning but do not
+fail the load.
+
+## Provides
+
+All four subsections are optional.
+
+- **`commands.<name>`** registers a top-level CLI verb. `exec` is a
+  path relative to the plugin root. The host dispatches via
+  `os/exec` with explicit argv and pipes through stdin/stdout/stderr.
+  The plugin's exit code becomes the coda exit code.
+- **`hooks.<event>`** is a list of glob patterns rooted at the plugin
+  dir. Matched executables run for the event. If `hooks` is omitted,
+  the host falls back to `<plugin-root>/hooks/<event>/*`.
+- **`providers.<name>`** registers a `session.Provider`
+  implementation. See `providers.md` for the executable contract.
+- **`mcp_tools.<name>`** registers a tool exposed via `coda mcp serve`.
+  See `mcp.md`.
+
+## Reserved names
+
+The following CLI verbs are reserved for the host. A plugin
+declaring a `commands.<name>` entry shadowing one of them is a
+load-time error:
+
+```
+version  agent  send  recv  ack  feature  mcp  help
+```
+
+## Dependencies
+
+`dependencies` is advisory. The host does not enforce; the plugin's
+`install` script is responsible for any system/runtime requirements.
+
+## Install
+
+`install` is a path (relative to plugin root) the user can run after
+dropping the plugin directory in place. The host does not run it
+automatically.

--- a/docs/plugin-contracts/providers.md
+++ b/docs/plugin-contracts/providers.md
@@ -1,0 +1,54 @@
+# Provider exec contract
+
+A provider plugin contributes a `session.Provider` implementation
+through a single executable declared as
+`provides.providers.<name>.exec`. The host spawns the executable
+once per provider method via `os/exec`, passes input on stdin, and
+parses output from stdout. Non-zero exit codes become errors.
+
+## Subcommand surface
+
+| Method                | argv                                | stdin                | stdout                                         |
+|-----------------------|-------------------------------------|----------------------|------------------------------------------------|
+| `Start(agent, cfg)`   | `start --agent=<name>`              | provider config JSON | trimmed first line is the session ID           |
+| `Stop(sessionID)`     | `stop <sessionID>`                  | (none)               | (none) — exit 0 on success                     |
+| `Deliver(sid, msg)`   | `deliver <sessionID>`               | message JSON         | `{"delivered": <bool>}`                        |
+| `Health(sid)`         | `health <sessionID>`                | (none)               | `{"State": "...", "Healthy": <bool>, "Detail": "..."}` |
+| `Output(sid, since?)` | `output <sessionID> [--since=<RFC3339>]` | (none)          | JSON array of `session.Message`                |
+| `Attach(sid)`         | `attach <sessionID>`                | (none)               | (none) — exit 0 on success                     |
+
+## JSON shapes
+
+`session.Message`:
+
+```json
+{
+  "ID": "ulid-or-string",
+  "From": "agent-a",
+  "To": "agent-b",
+  "Type": "note",
+  "Body": "<base64-encoded bytes>",
+  "CreatedAt": "2025-01-01T00:00:00Z"
+}
+```
+
+`session.ProviderConfig` is an opaque `map[string]string`.
+
+## Error semantics
+
+- **Zero exit code** is success. Any other exit is an error; the
+  host wraps stderr (or stdout if stderr is empty) into an error
+  string.
+- **Empty stdout from `start`** is a fatal error; the plugin must
+  print at least the session ID.
+- **Malformed JSON** on `deliver`, `health`, or `output` becomes a
+  parse error.
+
+## Implementation tips
+
+- One executable handles every subcommand; switch on `argv[1]`.
+- Read all of stdin before responding on `start` and `deliver`.
+- Keep stdout free of log noise — log to stderr.
+- Long-running operations (e.g., a real session loop) belong inside
+  `start`; the host treats stdout's first line as the ID and returns
+  immediately, so background the actual work.

--- a/docs/specs/171-plugin-host.md
+++ b/docs/specs/171-plugin-host.md
@@ -1,0 +1,327 @@
+# Spec #171 — Plugin host
+
+**Status:** drafted 2026-04-27, implemented in this PR.
+**Milestone:** [#166](https://github.com/users/evanstern/projects) coda v3 Go CLI
+**Card:** focus #171
+**Implements:** primitive 4 of 5
+
+## Vision
+
+The unblocking primitive. Until this lands, `ProviderRegistry`
+stays empty and `agent start` fails with "no provider registered."
+v3 stores everything correctly but executes nothing real. Plugin
+host is what makes v3 actually run.
+
+Five subsystems in one package (`internal/plugin/`):
+
+1. **Manifest parsing** — read `plugin.json` from each plugin dir
+2. **Loader** — discover, validate, return `[]Plugin`
+3. **SubprocessProvider** — implements `session.Provider` by
+   spawning plugin executables (the unblocking piece)
+4. **HookRunner** — replaces `internal/feature/`'s local runner
+   with a plugin-aware one
+5. **MCP server (stdio)** — JSON-RPC 2.0, three methods only
+6. **Command registration** — `coda <subcmd>` via subprocess
+
+Reference: v2 plugin contract at
+`~/projects/coda-archive/main/docs/plugin-contracts/{plugins,hooks}.md`.
+v3 inherits the manifest shape but the dispatch model diverges
+(Go binary, can't source bash).
+
+## Architectural decisions
+
+These are **answered**. Don't relitigate during implementation.
+
+- **Plugin command dispatch: subprocess (option a).** A plugin
+  command is an executable file in the plugin dir. v3 dispatches
+  via `exec.Command`. v2 plugins wrap their shell functions in
+  thin executable wrappers. No shell sourcing.
+- **Hook dispatch: provided by #171.** This card owns the full
+  hook runner including plugin-hook layering. #172 shipped a
+  minimal version (user dir only); #171 replaces it.
+- **MCP transport: stdio only.** No HTTP server. v2's shared
+  port-3111 server is out of scope.
+- **MCP library: hand-rolled JSON-RPC 2.0.** No new dependencies.
+  ~200-300 lines, full control over dispatch and error handling.
+- **Plugin storage: `~/.config/coda/plugins/<name>/`** (matches v2
+  default `$CODA_PLUGINS_DIR`). Override via `CODA_PLUGINS_DIR`.
+- **Manifest validation: strict for required keys, warn-only for
+  unknown.** Required: `name`, `version`, `coda`. Unknown
+  top-level keys log a warning, don't fail load.
+
+## Scope
+
+### 1. Manifest parsing (`internal/plugin/manifest.go`)
+
+Parse `plugin.json`. Schema (v2-derived, simplified for v3):
+
+```json
+{
+  "name":        "coda-codaclaw",
+  "version":     "0.1.0",
+  "coda":        "^0.1.0",
+  "description": "CodaClaw provider plugin",
+  "provides": {
+    "commands":  { "<name>": { "description": "...", "exec": "bin/cmd-<name>" } },
+    "hooks":     { "<event>": ["hooks/<event>/*"] },
+    "providers": { "<name>": { "exec": "bin/provider-<name>" } },
+    "mcp_tools": { "<tool>": { "description": "...", "command": ["arg1","arg2"] } }
+  },
+  "dependencies": { "system": ["..."], "go": "...", "npm": [...] },
+  "install": "scripts/install.sh"
+}
+```
+
+**Differences from v2:**
+
+- `commands.<name>` uses `exec` (path to executable), not
+  `handler` + `function` (bash sourcing). The `exec` path is
+  resolved relative to the plugin dir.
+- `providers.<name>` uses `exec` (path to executable), not a
+  directory of `auth.sh` + `status.sh`.
+- `dependencies.system/go/npm` are advisory; install enforces.
+
+**Out of scope:** `notifications`, `layouts`. v3 doesn't have
+those primitives — file separate cards if/when needed.
+
+### 2. Plugin discovery (`internal/plugin/loader.go`)
+
+```go
+type Loader struct { dir string }
+
+// Load discovers plugins in dir, parses manifests, returns the
+// set. Errors on: missing required manifest fields, unparseable
+// JSON. Warns on: unknown top-level keys, missing optional sections.
+func (l *Loader) Load(ctx context.Context) ([]Plugin, error)
+
+type Plugin struct {
+    Manifest Manifest
+    Root     string  // absolute path to plugin dir
+}
+```
+
+Default discovery dir: `$XDG_CONFIG_HOME/coda/plugins/` (or
+`~/.config/coda/plugins/`). Override via `CODA_PLUGINS_DIR`.
+
+### 3. Provider registration (the unblocking piece)
+
+For each plugin with a `providers` section, instantiate a
+`SubprocessProvider` that implements `session.Provider` by
+spawning the plugin's `provider.exec` binary with subcommand args:
+
+| Provider method        | Subprocess args            | Stdin/stdout                                       |
+|------------------------|----------------------------|----------------------------------------------------|
+| `Start(agent, cfg)`    | `start --agent=<name>`     | stdin: cfg JSON; stdout: session_id                |
+| `Stop(sessionID)`      | `stop <sessionID>`         | exit code 0 = ok                                   |
+| `Deliver(sid, msg)`    | `deliver <sid>`            | stdin: message JSON; stdout: `{delivered: bool}`   |
+| `Health(sid)`          | `health <sid>`             | stdout: `{state, healthy, detail}` JSON            |
+| `Output(sid, since?)`  | `output <sid> [--since=t]` | stdout: `[Message]` JSON                           |
+| `Attach(sid)`          | `attach <sid>`             | exit code 0 = ok                                   |
+
+The provider executable contract is published as
+`docs/plugin-contracts/providers.md` (new file in this PR).
+
+After loader runs, register every discovered provider into the
+`session.ProviderRegistry`. Wire this into `cmd/coda/main.go`'s
+`defaultRegistry()` so it's no longer empty.
+
+### 4. Hook dispatch (`internal/plugin/hooks.go`)
+
+```go
+// HookRunner runs sorted scripts for a given event from both the
+// user hooks dir and any manifest-declared plugin hook dirs.
+type HookRunner struct { /* dirs */ }
+
+// Run executes hooks in two layers:
+//   1. user dir: $XDG_CONFIG_HOME/coda/hooks/<event>/
+//   2. plugin dirs: each plugin's hooks/<event>/* (manifest-declared)
+// Within each layer, sort by LC_ALL=C filename. Failures warn to
+// stderr, don't block. env passed via os.Environ + extras.
+func (h *HookRunner) Run(ctx context.Context, event string, env map[string]string) error
+```
+
+Must satisfy the `feature.HookRunner` interface that #172
+shipped. The replacement in `cmd/coda/main.go` is a one-line wire
+change: replace `feature.NewLocalHookRunner(...)` with
+`plugin.NewHookRunner(...)`.
+
+**Hook events the new runner must support** (the four #172
+fires today):
+
+- `pre-feature-create`
+- `post-feature-create`
+- `pre-feature-teardown`
+- `post-feature-finish`
+
+**Trap:** v2 docs use `CODA_*` env vars exactly. Match them so v2
+plugins port cleanly: `CODA_PROJECT_NAME`, `CODA_PROJECT_DIR`,
+`CODA_FEATURE_BRANCH`, `CODA_WORKTREE_DIR`. #172 already sets
+these correctly; the new runner just needs to pass them through.
+
+### 5. MCP server (stdio)
+
+A coda-managed stdio MCP server that exposes plugin-declared
+`mcp_tools`.
+
+```go
+// cmd/coda/main.go new top-level subcommand:
+//   coda mcp serve   # reads jsonrpc from stdin, writes to stdout
+//   coda mcp tools   # lists registered tools (debugging)
+```
+
+The server reads tool registrations from loaded plugins. When a
+client calls a tool, the server dispatches via `exec.Command` to
+the plugin's declared `command` array, passes JSON params on
+stdin, returns stdout as the tool result.
+
+**Scope guardrail:** implement only `initialize`, `tools/list`,
+and `tools/call`. Do NOT implement prompts, resources, sampling,
+completion, logging, or any other MCP method. Future methods are
+follow-up cards.
+
+**Library: hand-rolled JSON-RPC 2.0.** No new dependencies.
+
+JSON-RPC 2.0 essentials:
+
+- Request: `{"jsonrpc": "2.0", "id": <int|string>, "method": "...", "params": {...}}`
+- Response (success): `{"jsonrpc": "2.0", "id": <same>, "result": {...}}`
+- Response (error): `{"jsonrpc": "2.0", "id": <same>, "error": {"code": <int>, "message": "..."}}`
+- Notification (no response): same shape as request, no `id`
+- Standard error codes: -32700 parse, -32600 invalid request,
+  -32601 method not found, -32602 invalid params, -32603 internal
+
+MCP-specific shapes:
+
+- `initialize` — params: `{"protocolVersion": "...", "capabilities": {...}}`. Response: server capabilities.
+- `tools/list` — params: optional pagination cursor. Response: `{"tools": [{"name", "description", "inputSchema"}]}`.
+- `tools/call` — params: `{"name": "...", "arguments": {...}}`. Response: `{"content": [{"type": "text", "text": "..."}], "isError": bool}`.
+
+Stdio framing: newline-delimited JSON-RPC (one JSON object per
+line). The MCP spec also defines content-length-framed transport
+for non-stdio; not in scope here.
+
+### 6. Command registration
+
+For each plugin's `provides.commands.<name>`, register the
+command in `cmd/coda/main.go`. Dispatch via:
+
+```go
+exec.Command("<plugin.Root>/<exec>", remaining_args...)
+```
+
+Pass through stdin/stdout/stderr. Plugin's exit code becomes
+coda's exit code.
+
+**Reserved core subcommands** must NOT be shadowable: `version`,
+`agent`, `send`, `recv`, `ack`, `feature`, `mcp`. Plugins
+attempting to register these get a **load-time error** (not a
+silent skip — the plugin author needs to know).
+
+## Repo layout (new files)
+
+```
+internal/plugin/
+  plugin.go              (currently stub — replace)
+  manifest.go            Manifest struct, Parse(), validation
+  manifest_test.go
+  loader.go              Loader, discovery, validation
+  loader_test.go
+  provider.go            SubprocessProvider (implements session.Provider)
+  provider_test.go
+  hooks.go               HookRunner (replaces feature.localHookRunner)
+  hooks_test.go
+  mcp.go                 stdio MCP server (hand-rolled JSON-RPC)
+  mcp_test.go
+  command.go             plugin-command dispatch helpers
+  command_test.go
+docs/plugin-contracts/
+  plugins.md             v3 plugin.json schema + how to write a plugin
+  hooks.md               v3 hook events + env vars
+  providers.md           provider exec contract (subcommand args, JSON shapes)
+  mcp.md                 v3 MCP tool contract
+docs/specs/
+  171-plugin-host.md     (this doc)
+```
+
+`cmd/coda/main.go`:
+
+- New `mcp` top-level subcommand (`mcp serve`, `mcp tools`)
+- `defaultRegistry()` replaced with a function that loads plugins
+- Hook runner wire change: `feature.NewLocalHookRunner(...)` →
+  `plugin.NewHookRunner(...)`
+
+## Test surface
+
+**Unit tests:**
+
+- **Manifest parse:** valid, missing required fields, unknown
+  top-level keys (warn, not fail), invalid JSON.
+- **Loader:** empty dir, single plugin, multiple plugins,
+  malformed plugin (one plugin failing doesn't kill others).
+- **HookRunner:** user-dir only, plugin-dirs only, both, sort
+  order, non-executable files skipped, failure warns but doesn't
+  abort.
+- **MCP server:** initialize, tools/list, tools/call (golden
+  JSON-RPC fixtures). Error responses for unknown method, bad
+  params.
+- **SubprocessProvider:** each method calls the right exec args,
+  marshals JSON correctly, handles non-zero exit codes.
+
+**Integration tests:**
+
+- End-to-end plugin load: scaffold a fake plugin in a tempdir
+  with a real executable (a tiny Go binary built in-test, or a
+  shell script), exercise commands/hooks/provider/mcp paths.
+- Reserved-name shadowing rejected at load (assert error message
+  names the conflicting subcommand).
+
+## Acceptance gate
+
+```bash
+cd <worktree>
+go build ./...
+go vet ./...
+go test ./... -count=1 -race
+```
+
+All three must exit 0.
+
+## Out of scope
+
+- Plugin install/remove CLI (`coda plugin install`). Follow-up
+  card. For now, plugins are dropped manually into
+  `~/.config/coda/plugins/`.
+- HTTP MCP server (v2 had a shared port-3111 server; v3 doesn't
+  yet).
+- v2 `provides.notifications` / `provides.layouts` — not v3
+  primitives.
+- Plugin update / strict version-checking against `coda` field
+  in manifest. Parse it, log a warning on mismatch. Strict
+  enforcement is a follow-up card.
+- Don't touch `internal/identity/`, `internal/messages/`,
+  `internal/session/` (other than wiring providers into the
+  registry through `cmd/coda/main.go`).
+- Don't fix the harness FEATURE SESSION preamble (#188 — Riley
+  scope).
+- Don't update CLI usage strings (#185).
+
+## Done when
+
+- All six subsystems (manifest, loader, providers, hooks, MCP,
+  commands) implemented with tests
+- Four contract docs in `docs/plugin-contracts/`
+- `defaultRegistry()` in `cmd/coda/main.go` is no longer always-empty
+- `coda mcp serve` works end-to-end against a fixture plugin
+- Acceptance gate exits 0
+- AGENTS.md updated to reflect the plugin host shipping
+- This spec doc committed at `docs/specs/171-plugin-host.md`
+- PR opened against main
+
+## Coordination
+
+- **Depends on:** #172 (HookRunner interface). Already shipped at
+  PR #8 / commit `75e80db`.
+- **Unblocks:** #173 (codaclaw provider) absolutely needs this —
+  Kit's surface but the interface is ours.
+- **Foreshadows:** #174 (port v2 plugins) requires this contract
+  finalized.

--- a/internal/plugin/command.go
+++ b/internal/plugin/command.go
@@ -1,0 +1,121 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"sort"
+)
+
+// ReservedSubcommands are the core CLI verbs plugins are forbidden
+// from shadowing. Attempts produce a load-time error so the plugin
+// author sees the conflict.
+var ReservedSubcommands = map[string]struct{}{
+	"version": {},
+	"agent":   {},
+	"send":    {},
+	"recv":    {},
+	"ack":     {},
+	"feature": {},
+	"mcp":     {},
+	"help":    {},
+}
+
+// CommandRegistration binds a command name to a plugin's executable
+// path (resolved absolute) plus the source plugin name for error
+// reporting.
+type CommandRegistration struct {
+	Name        string
+	Plugin      string
+	Exec        string
+	Description string
+}
+
+// CommandRegistry is the set of plugin-contributed CLI commands.
+type CommandRegistry struct {
+	commands map[string]CommandRegistration
+}
+
+// BuildCommandRegistry walks plugins, validates their command
+// declarations against ReservedSubcommands, and returns a registry.
+// A duplicate or reserved name is a load-time error; the error
+// message names the offending plugin and command.
+func BuildCommandRegistry(plugins []Plugin) (*CommandRegistry, error) {
+	r := &CommandRegistry{commands: map[string]CommandRegistration{}}
+	for _, p := range plugins {
+		names := make([]string, 0, len(p.Manifest.Provides.Commands))
+		for n := range p.Manifest.Provides.Commands {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			spec := p.Manifest.Provides.Commands[name]
+			if _, reserved := ReservedSubcommands[name]; reserved {
+				return nil, fmt.Errorf("plugin %s: command %q shadows reserved coda subcommand", p.Manifest.Name, name)
+			}
+			if existing, ok := r.commands[name]; ok {
+				return nil, fmt.Errorf("plugin %s: command %q already registered by plugin %s", p.Manifest.Name, name, existing.Plugin)
+			}
+			full := spec.Exec
+			if !filepath.IsAbs(full) {
+				full = filepath.Join(p.Root, spec.Exec)
+			}
+			r.commands[name] = CommandRegistration{
+				Name:        name,
+				Plugin:      p.Manifest.Name,
+				Exec:        full,
+				Description: spec.Description,
+			}
+		}
+	}
+	return r, nil
+}
+
+// Lookup returns the registration for name, and a bool indicating
+// whether it exists.
+func (r *CommandRegistry) Lookup(name string) (CommandRegistration, bool) {
+	if r == nil {
+		return CommandRegistration{}, false
+	}
+	c, ok := r.commands[name]
+	return c, ok
+}
+
+// Names returns sorted command names.
+func (r *CommandRegistry) Names() []string {
+	if r == nil {
+		return nil
+	}
+	out := make([]string, 0, len(r.commands))
+	for n := range r.commands {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Dispatch runs the plugin command with args. Stdin/stdout/stderr
+// pass through; the plugin's exit code is returned (0 on success,
+// the underlying ExitError code otherwise; -1 on spawn failure).
+func (r *CommandRegistry) Dispatch(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	reg, ok := r.Lookup(name)
+	if !ok {
+		fmt.Fprintf(stderr, "unknown command: %s\n", name)
+		return 2
+	}
+	cmd := exec.CommandContext(ctx, reg.Exec, args...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	if err == nil {
+		return 0
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return ee.ExitCode()
+	}
+	fmt.Fprintf(stderr, "error: run %s: %v\n", reg.Exec, err)
+	return 1
+}

--- a/internal/plugin/command.go
+++ b/internal/plugin/command.go
@@ -97,8 +97,9 @@ func (r *CommandRegistry) Names() []string {
 }
 
 // Dispatch runs the plugin command with args. Stdin/stdout/stderr
-// pass through; the plugin's exit code is returned (0 on success,
-// the underlying ExitError code otherwise; -1 on spawn failure).
+// pass through. Exit code: 0 on success; the plugin's exit code
+// from a non-zero exit; 1 on spawn failure (with the error printed
+// to stderr); 2 if name doesn't resolve to a registered command.
 func (r *CommandRegistry) Dispatch(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	reg, ok := r.Lookup(name)
 	if !ok {

--- a/internal/plugin/command_test.go
+++ b/internal/plugin/command_test.go
@@ -1,0 +1,112 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildCommandRegistry_Basic(t *testing.T) {
+	root := t.TempDir()
+	plugins := []Plugin{{
+		Root: root,
+		Manifest: Manifest{
+			Name: "demo",
+			Provides: Provides{
+				Commands: map[string]CommandSpec{
+					"hello": {Description: "say hi", Exec: "bin/hello"},
+				},
+			},
+		},
+	}}
+	r, err := BuildCommandRegistry(plugins)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	reg, ok := r.Lookup("hello")
+	if !ok {
+		t.Fatal("hello not registered")
+	}
+	if reg.Plugin != "demo" {
+		t.Fatalf("plugin=%q", reg.Plugin)
+	}
+	if reg.Exec != filepath.Join(root, "bin/hello") {
+		t.Fatalf("exec=%q", reg.Exec)
+	}
+}
+
+func TestBuildCommandRegistry_ReservedName(t *testing.T) {
+	for _, name := range []string{"version", "agent", "send", "recv", "ack", "feature", "mcp"} {
+		t.Run(name, func(t *testing.T) {
+			plugins := []Plugin{{
+				Root: t.TempDir(),
+				Manifest: Manifest{
+					Name:     "naughty",
+					Provides: Provides{Commands: map[string]CommandSpec{name: {Exec: "bin/x"}}},
+				},
+			}}
+			_, err := BuildCommandRegistry(plugins)
+			if err == nil {
+				t.Fatalf("expected error for reserved %q", name)
+			}
+			if !strings.Contains(err.Error(), name) || !strings.Contains(err.Error(), "naughty") {
+				t.Fatalf("error must name plugin and command, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildCommandRegistry_DuplicateName(t *testing.T) {
+	plugins := []Plugin{
+		{Root: t.TempDir(), Manifest: Manifest{Name: "a", Provides: Provides{Commands: map[string]CommandSpec{"go": {Exec: "x"}}}}},
+		{Root: t.TempDir(), Manifest: Manifest{Name: "b", Provides: Provides{Commands: map[string]CommandSpec{"go": {Exec: "y"}}}}},
+	}
+	_, err := BuildCommandRegistry(plugins)
+	if err == nil {
+		t.Fatal("expected duplicate-name error")
+	}
+	if !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestCommandRegistry_Dispatch(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\necho \"hi $1\"\nexit 3\n"
+	exec := filepath.Join(binDir, "hello")
+	if err := os.WriteFile(exec, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugins := []Plugin{{
+		Root:     root,
+		Manifest: Manifest{Name: "demo", Provides: Provides{Commands: map[string]CommandSpec{"hello": {Exec: "bin/hello"}}}},
+	}}
+	r, err := BuildCommandRegistry(plugins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := r.Dispatch(context.Background(), "hello", []string{"there"}, nil, &stdout, &stderr)
+	if code != 3 {
+		t.Fatalf("exit code=%d", code)
+	}
+	if !strings.Contains(stdout.String(), "hi there") {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
+func TestCommandRegistry_DispatchUnknown(t *testing.T) {
+	r, _ := BuildCommandRegistry(nil)
+	var stderr bytes.Buffer
+	code := r.Dispatch(context.Background(), "noop", nil, nil, &bytes.Buffer{}, &stderr)
+	if code != 2 {
+		t.Fatalf("expected exit 2, got %d", code)
+	}
+}

--- a/internal/plugin/hooks.go
+++ b/internal/plugin/hooks.go
@@ -1,0 +1,162 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// HookRunner runs lifecycle hook scripts in two layers:
+//
+//  1. The user dir: $XDG_CONFIG_HOME/coda/hooks/<event>/
+//  2. Each plugin's hooks/<event>/ directory
+//
+// Within each layer, scripts run in LC_ALL=C filename order. Failures
+// warn to stderr and don't block subsequent hooks. Non-executable
+// regular files are skipped silently.
+type HookRunner struct {
+	UserDir string
+	Plugins []Plugin
+	Stderr  io.Writer
+}
+
+// NewHookRunner returns a HookRunner. If userDir is empty,
+// DefaultHooksDir is used. plugins is the set returned by Loader.Load
+// (the runner uses each plugin's Root + "hooks" subdir).
+func NewHookRunner(userDir string, plugins []Plugin, stderr io.Writer) *HookRunner {
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	if userDir == "" {
+		userDir = DefaultHooksDir()
+	}
+	return &HookRunner{UserDir: userDir, Plugins: plugins, Stderr: stderr}
+}
+
+// DefaultHooksDir mirrors feature.defaultHooksDir(): XDG_CONFIG_HOME
+// then $HOME/.config/coda/hooks.
+func DefaultHooksDir() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "coda", "hooks")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "coda", "hooks")
+}
+
+// Run executes hooks for event in user→plugin layer order. env is
+// merged into os.Environ for each subprocess. Always returns nil
+// (warn-only contract).
+func (h *HookRunner) Run(ctx context.Context, event string, env map[string]string) error {
+	merged := mergedEnv(env)
+	if h.UserDir != "" {
+		h.runDir(ctx, "user", filepath.Join(h.UserDir, event), event, merged)
+	}
+	for _, p := range h.Plugins {
+		dirs, ok := p.Manifest.Provides.Hooks[event]
+		if !ok {
+			h.runDir(ctx, p.Manifest.Name, filepath.Join(p.Root, "hooks", event), event, merged)
+			continue
+		}
+		for _, pattern := range dirs {
+			h.runPattern(ctx, p, pattern, event, merged)
+		}
+	}
+	return nil
+}
+
+func (h *HookRunner) runDir(ctx context.Context, layer, dir, event string, env []string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		fmt.Fprintf(h.Stderr, "warn: read hooks dir %s: %v\n", dir, err)
+		return
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		h.runOne(ctx, path, event, name, env)
+	}
+}
+
+func (h *HookRunner) runPattern(ctx context.Context, p Plugin, pattern, event string, env []string) {
+	full := pattern
+	if !filepath.IsAbs(full) {
+		full = filepath.Join(p.Root, pattern)
+	}
+	matches, err := filepath.Glob(full)
+	if err != nil {
+		fmt.Fprintf(h.Stderr, "warn: hook glob %s: %v\n", full, err)
+		return
+	}
+	sort.Strings(matches)
+	for _, path := range matches {
+		h.runOne(ctx, path, event, filepath.Base(path), env)
+	}
+}
+
+func (h *HookRunner) runOne(ctx context.Context, path, event, name string, env []string) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		fmt.Fprintf(h.Stderr, "warn: lstat hook %s: %v\n", path, err)
+		return
+	}
+	if !info.Mode().IsRegular() {
+		return
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return
+	}
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Env = env
+	cmd.Stdout = h.Stderr
+	cmd.Stderr = h.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(h.Stderr, "warn: hook %s/%s failed: %v\n", event, name, err)
+	}
+}
+
+func mergedEnv(env map[string]string) []string {
+	base := os.Environ()
+	if len(env) == 0 {
+		return base
+	}
+	overrides := make(map[string]string, len(env))
+	for k, v := range env {
+		overrides[k] = v
+	}
+	out := make([]string, 0, len(base)+len(overrides))
+	for _, kv := range base {
+		key := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			key = kv[:i]
+		}
+		if _, override := overrides[key]; override {
+			continue
+		}
+		out = append(out, kv)
+	}
+	keys := make([]string, 0, len(overrides))
+	for k := range overrides {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		out = append(out, k+"="+overrides[k])
+	}
+	return out
+}

--- a/internal/plugin/hooks_test.go
+++ b/internal/plugin/hooks_test.go
@@ -1,0 +1,163 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evanstern/coda/internal/feature"
+)
+
+func TestHookRunner_SatisfiesFeatureInterface(t *testing.T) {
+	var _ feature.HookRunner = (*HookRunner)(nil)
+}
+
+func writeHook(t *testing.T, dir, name, body string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"+body), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHookRunner_UserOnly(t *testing.T) {
+	userDir := t.TempDir()
+	out := filepath.Join(t.TempDir(), "log.txt")
+	writeHook(t, filepath.Join(userDir, "pre-feature-create"), "10-a", "echo user-a >> "+out+"\n", 0o755)
+	r := NewHookRunner(userDir, nil, &bytes.Buffer{})
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(out)
+	if string(got) != "user-a\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestHookRunner_PluginOnly(t *testing.T) {
+	pluginRoot := t.TempDir()
+	out := filepath.Join(t.TempDir(), "log.txt")
+	writeHook(t, filepath.Join(pluginRoot, "hooks", "pre-feature-create"), "10-a", "echo plugin-a >> "+out+"\n", 0o755)
+	plugins := []Plugin{{Root: pluginRoot, Manifest: Manifest{Name: "p1"}}}
+	r := NewHookRunner(t.TempDir(), plugins, &bytes.Buffer{})
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(out)
+	if string(got) != "plugin-a\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestHookRunner_BothLayered(t *testing.T) {
+	userDir := t.TempDir()
+	pluginRoot := t.TempDir()
+	out := filepath.Join(t.TempDir(), "log.txt")
+	writeHook(t, filepath.Join(userDir, "pre-feature-create"), "10-u", "echo user >> "+out+"\n", 0o755)
+	writeHook(t, filepath.Join(pluginRoot, "hooks", "pre-feature-create"), "10-p", "echo plugin >> "+out+"\n", 0o755)
+	plugins := []Plugin{{Root: pluginRoot, Manifest: Manifest{Name: "p1"}}}
+	r := NewHookRunner(userDir, plugins, &bytes.Buffer{})
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(out)
+	if string(got) != "user\nplugin\n" {
+		t.Fatalf("layer order wrong: %q", got)
+	}
+}
+
+func TestHookRunner_SortOrder(t *testing.T) {
+	userDir := t.TempDir()
+	out := filepath.Join(t.TempDir(), "log.txt")
+	dir := filepath.Join(userDir, "post-feature-create")
+	for _, n := range []string{"30-c", "10-a", "20-b"} {
+		writeHook(t, dir, n, "echo "+n+" >> "+out+"\n", 0o755)
+	}
+	r := NewHookRunner(userDir, nil, &bytes.Buffer{})
+	if err := r.Run(context.Background(), "post-feature-create", nil); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(out)
+	if string(got) != "10-a\n20-b\n30-c\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestHookRunner_NonExecutableSkipped(t *testing.T) {
+	userDir := t.TempDir()
+	out := filepath.Join(t.TempDir(), "log.txt")
+	writeHook(t, filepath.Join(userDir, "pre-feature-create"), "10-skip", "echo skip > "+out+"\n", 0o644)
+	r := NewHookRunner(userDir, nil, &bytes.Buffer{})
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("non-executable hook ran: %v", err)
+	}
+}
+
+func TestHookRunner_FailureWarnsButContinues(t *testing.T) {
+	userDir := t.TempDir()
+	out := filepath.Join(t.TempDir(), "log.txt")
+	writeHook(t, filepath.Join(userDir, "pre-feature-create"), "10-fail", "exit 1\n", 0o755)
+	writeHook(t, filepath.Join(userDir, "pre-feature-create"), "20-ok", "echo ok > "+out+"\n", 0o755)
+	var stderr bytes.Buffer
+	r := NewHookRunner(userDir, nil, &stderr)
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr.String(), "warn:") {
+		t.Fatalf("expected warning: %q", stderr.String())
+	}
+	if got, _ := os.ReadFile(out); string(got) != "ok\n" {
+		t.Fatalf("subsequent hook didn't run: %q", got)
+	}
+}
+
+func TestHookRunner_ManifestGlob(t *testing.T) {
+	pluginRoot := t.TempDir()
+	out := filepath.Join(t.TempDir(), "log.txt")
+	writeHook(t, filepath.Join(pluginRoot, "myhooks", "pre"), "01-a", "echo glob-a >> "+out+"\n", 0o755)
+	writeHook(t, filepath.Join(pluginRoot, "myhooks", "pre"), "02-b", "echo glob-b >> "+out+"\n", 0o755)
+	plugins := []Plugin{{
+		Root: pluginRoot,
+		Manifest: Manifest{
+			Name: "p1",
+			Provides: Provides{
+				Hooks: map[string][]string{"pre-feature-create": {"myhooks/pre/*"}},
+			},
+		},
+	}}
+	r := NewHookRunner(t.TempDir(), plugins, &bytes.Buffer{})
+	if err := r.Run(context.Background(), "pre-feature-create", nil); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(out)
+	if string(got) != "glob-a\nglob-b\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestHookRunner_EnvPassthrough(t *testing.T) {
+	userDir := t.TempDir()
+	out := filepath.Join(t.TempDir(), "env.txt")
+	body := "printf '%s|%s\\n' \"$CODA_PROJECT_NAME\" \"$CODA_FEATURE_BRANCH\" > " + out + "\n"
+	writeHook(t, filepath.Join(userDir, "pre-feature-create"), "10-env", body, 0o755)
+	r := NewHookRunner(userDir, nil, &bytes.Buffer{})
+	env := map[string]string{
+		"CODA_PROJECT_NAME":   "demo",
+		"CODA_FEATURE_BRANCH": "feat",
+	}
+	if err := r.Run(context.Background(), "pre-feature-create", env); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(out)
+	if string(got) != "demo|feat\n" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -1,0 +1,100 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Loader discovers plugins under a single root directory. Each
+// immediate subdirectory containing a plugin.json file is treated as
+// a plugin. Malformed manifests are reported via Warn but do not
+// abort the load.
+type Loader struct {
+	Dir  string
+	Warn io.Writer
+}
+
+// NewLoader returns a Loader that reads plugins from dir. If dir is
+// empty, DefaultDir is used. Warnings are sent to warn (or
+// io.Discard if nil).
+func NewLoader(dir string, warn io.Writer) *Loader {
+	if warn == nil {
+		warn = io.Discard
+	}
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	return &Loader{Dir: dir, Warn: warn}
+}
+
+// DefaultDir returns the default plugins directory. CODA_PLUGINS_DIR
+// wins, then $XDG_CONFIG_HOME/coda/plugins, then
+// $HOME/.config/coda/plugins. Empty string if no home is detectable.
+func DefaultDir() string {
+	if d := os.Getenv("CODA_PLUGINS_DIR"); d != "" {
+		return d
+	}
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "coda", "plugins")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "coda", "plugins")
+}
+
+// Load scans Dir for plugins and returns the parsed set. A missing
+// Dir is treated as no plugins (returns empty slice, nil error).
+// Plugins whose manifest fails to parse are skipped with a warning;
+// Load only returns a non-nil error for fundamental I/O issues.
+func (l *Loader) Load(ctx context.Context) ([]Plugin, error) {
+	if l.Dir == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(l.Dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read plugins dir %s: %w", l.Dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	plugins := make([]Plugin, 0, len(names))
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		root := filepath.Join(l.Dir, name)
+		manifestPath := filepath.Join(root, "plugin.json")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			fmt.Fprintf(l.Warn, "warn: read %s: %v\n", manifestPath, err)
+			continue
+		}
+		m, err := Parse(data, l.Warn)
+		if err != nil {
+			fmt.Fprintf(l.Warn, "warn: parse %s: %v\n", manifestPath, err)
+			continue
+		}
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			absRoot = root
+		}
+		plugins = append(plugins, Plugin{Manifest: m, Root: absRoot})
+	}
+	return plugins, nil
+}

--- a/internal/plugin/loader_test.go
+++ b/internal/plugin/loader_test.go
@@ -1,0 +1,103 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManifest(t *testing.T, dir, name, json string) string {
+	t.Helper()
+	root := filepath.Join(dir, name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugin.json"), []byte(json), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestLoader_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLoader(dir, nil)
+	plugins, err := l.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(plugins) != 0 {
+		t.Fatalf("expected 0 plugins, got %d", len(plugins))
+	}
+}
+
+func TestLoader_MissingDir(t *testing.T) {
+	l := NewLoader(filepath.Join(t.TempDir(), "does-not-exist"), nil)
+	plugins, err := l.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(plugins) != 0 {
+		t.Fatalf("expected 0 plugins, got %d", len(plugins))
+	}
+}
+
+func TestLoader_Multiple(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "alpha", `{"name":"alpha","version":"0.1","coda":"^0.1"}`)
+	writeManifest(t, dir, "beta", `{"name":"beta","version":"0.1","coda":"^0.1"}`)
+	l := NewLoader(dir, nil)
+	plugins, err := l.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(plugins) != 2 {
+		t.Fatalf("expected 2 plugins, got %d", len(plugins))
+	}
+	if plugins[0].Manifest.Name != "alpha" || plugins[1].Manifest.Name != "beta" {
+		t.Fatalf("plugins not sorted: %s, %s", plugins[0].Manifest.Name, plugins[1].Manifest.Name)
+	}
+}
+
+func TestLoader_OneMalformedOthersSucceed(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "good", `{"name":"good","version":"0.1","coda":"^0.1"}`)
+	writeManifest(t, dir, "bad", `{not json`)
+	var warn bytes.Buffer
+	l := NewLoader(dir, &warn)
+	plugins, err := l.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(plugins) != 1 || plugins[0].Manifest.Name != "good" {
+		t.Fatalf("expected only good plugin, got %+v", plugins)
+	}
+	if !strings.Contains(warn.String(), "warn: parse") {
+		t.Fatalf("expected parse warning: %q", warn.String())
+	}
+}
+
+func TestLoader_NoManifestSkipped(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "no-manifest"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeManifest(t, dir, "ok", `{"name":"ok","version":"0.1","coda":"^0.1"}`)
+	l := NewLoader(dir, nil)
+	plugins, err := l.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(plugins) != 1 || plugins[0].Manifest.Name != "ok" {
+		t.Fatalf("got %+v", plugins)
+	}
+}
+
+func TestDefaultDir_EnvOverride(t *testing.T) {
+	t.Setenv("CODA_PLUGINS_DIR", "/custom/plugins")
+	if got := DefaultDir(); got != "/custom/plugins" {
+		t.Fatalf("DefaultDir=%q", got)
+	}
+}

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -1,0 +1,137 @@
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Manifest is the parsed shape of a v3 plugin.json. Required fields
+// are Name, Version, and Coda. The four provides sections are all
+// optional.
+type Manifest struct {
+	Name        string       `json:"name"`
+	Version     string       `json:"version"`
+	Coda        string       `json:"coda"`
+	Description string       `json:"description,omitempty"`
+	Provides    Provides     `json:"provides,omitempty"`
+	Deps        Dependencies `json:"dependencies,omitempty"`
+	Install     string       `json:"install,omitempty"`
+	Unknown     []string     `json:"-"`
+}
+
+// Provides groups the four kinds of contributions a plugin can ship.
+type Provides struct {
+	Commands  map[string]CommandSpec  `json:"commands,omitempty"`
+	Hooks     map[string][]string     `json:"hooks,omitempty"`
+	Providers map[string]ProviderSpec `json:"providers,omitempty"`
+	MCPTools  map[string]MCPTool      `json:"mcp_tools,omitempty"`
+}
+
+// CommandSpec is the manifest shape of a plugin-contributed CLI
+// command. Exec is a path relative to the plugin's root dir.
+type CommandSpec struct {
+	Description string `json:"description,omitempty"`
+	Exec        string `json:"exec"`
+}
+
+// ProviderSpec is the manifest shape of a plugin-contributed
+// session.Provider. Exec is a path relative to the plugin's root dir.
+type ProviderSpec struct {
+	Exec string `json:"exec"`
+}
+
+// MCPTool is the manifest shape of a plugin-contributed MCP tool.
+// Command is the argv slice the host will exec when the tool is
+// invoked; the first element is resolved relative to the plugin root
+// if it is not absolute.
+type MCPTool struct {
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"inputSchema,omitempty"`
+	Command     []string       `json:"command"`
+}
+
+// Dependencies is advisory only — install scripts enforce; the host
+// does not check.
+type Dependencies struct {
+	System []string `json:"system,omitempty"`
+	Go     string   `json:"go,omitempty"`
+	NPM    []string `json:"npm,omitempty"`
+}
+
+// knownTopLevel is the set of recognized top-level keys. Anything
+// else triggers a warning when Parse is given a non-nil warn writer.
+var knownTopLevel = map[string]struct{}{
+	"name":         {},
+	"version":      {},
+	"coda":         {},
+	"description":  {},
+	"provides":     {},
+	"dependencies": {},
+	"install":      {},
+}
+
+// knownProvides is the set of recognized provides.* keys.
+var knownProvides = map[string]struct{}{
+	"commands":  {},
+	"hooks":     {},
+	"providers": {},
+	"mcp_tools": {},
+}
+
+// Parse decodes a plugin.json byte slice into a Manifest. Required
+// keys (name, version, coda) must be present and non-empty. Unknown
+// top-level keys are recorded on Manifest.Unknown and, if warn is
+// non-nil, also written there as "warn: ..." lines.
+func Parse(data []byte, warn io.Writer) (Manifest, error) {
+	var raw map[string]json.RawMessage
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&raw); err != nil {
+		return Manifest{}, fmt.Errorf("decode plugin.json: %w", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Manifest{}, fmt.Errorf("decode plugin.json: %w", err)
+	}
+	if m.Name == "" {
+		return Manifest{}, fmt.Errorf("manifest: missing required field %q", "name")
+	}
+	if m.Version == "" {
+		return Manifest{}, fmt.Errorf("manifest: missing required field %q", "version")
+	}
+	if m.Coda == "" {
+		return Manifest{}, fmt.Errorf("manifest: missing required field %q", "coda")
+	}
+	unknown := make([]string, 0)
+	for k := range raw {
+		if _, ok := knownTopLevel[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+	sort.Strings(unknown)
+	m.Unknown = unknown
+	if warn != nil {
+		for _, k := range unknown {
+			fmt.Fprintf(warn, "warn: plugin %s: unknown manifest key %q\n", m.Name, k)
+		}
+		if pr, ok := raw["provides"]; ok {
+			var pmap map[string]json.RawMessage
+			if err := json.Unmarshal(pr, &pmap); err == nil {
+				keys := make([]string, 0, len(pmap))
+				for k := range pmap {
+					if _, ok := knownProvides[k]; !ok {
+						keys = append(keys, k)
+					}
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					fmt.Fprintf(warn, "warn: plugin %s: unknown provides key %q\n", m.Name, k)
+				}
+			}
+		}
+	}
+	return m, nil
+}

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -1,0 +1,106 @@
+package plugin
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParse_Valid(t *testing.T) {
+	data := []byte(`{
+  "name": "demo",
+  "version": "0.1.0",
+  "coda": "^0.1.0",
+  "description": "demo plugin",
+  "provides": {
+    "commands": {"hello": {"description": "say hi", "exec": "bin/hello"}},
+    "providers": {"demo": {"exec": "bin/provider"}},
+    "hooks": {"pre-feature-create": ["hooks/pre/*"]},
+    "mcp_tools": {"echo": {"description": "echo back", "command": ["bin/echo"]}}
+  }
+}`)
+	m, err := Parse(data, nil)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if m.Name != "demo" || m.Version != "0.1.0" || m.Coda != "^0.1.0" {
+		t.Fatalf("required fields: %+v", m)
+	}
+	if got := m.Provides.Commands["hello"].Exec; got != "bin/hello" {
+		t.Fatalf("commands.hello.exec=%q", got)
+	}
+	if got := m.Provides.Providers["demo"].Exec; got != "bin/provider" {
+		t.Fatalf("providers.demo.exec=%q", got)
+	}
+	if got := m.Provides.MCPTools["echo"].Command; len(got) != 1 || got[0] != "bin/echo" {
+		t.Fatalf("mcp_tools.echo.command=%v", got)
+	}
+	if hooks := m.Provides.Hooks["pre-feature-create"]; len(hooks) != 1 {
+		t.Fatalf("hooks=%v", hooks)
+	}
+}
+
+func TestParse_MissingRequired(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		miss string
+	}{
+		{"no name", `{"version":"0.1.0","coda":"^0.1.0"}`, `"name"`},
+		{"no version", `{"name":"x","coda":"^0.1.0"}`, `"version"`},
+		{"no coda", `{"name":"x","version":"0.1.0"}`, `"coda"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Parse([]byte(c.json), nil)
+			if err == nil {
+				t.Fatalf("expected error for %s", c.name)
+			}
+			if !strings.Contains(err.Error(), c.miss) {
+				t.Fatalf("expected error to mention %s, got %v", c.miss, err)
+			}
+		})
+	}
+}
+
+func TestParse_UnknownKeyWarns(t *testing.T) {
+	data := []byte(`{"name":"x","version":"0.1.0","coda":"^0.1.0","weirdo":1}`)
+	var warn bytes.Buffer
+	m, err := Parse(data, &warn)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !strings.Contains(warn.String(), `unknown manifest key "weirdo"`) {
+		t.Fatalf("warn missing: %q", warn.String())
+	}
+	found := false
+	for _, k := range m.Unknown {
+		if k == "weirdo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Unknown=%v missing weirdo", m.Unknown)
+	}
+}
+
+func TestParse_InvalidJSON(t *testing.T) {
+	_, err := Parse([]byte(`{not json`), nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestParse_UnknownProvidesWarns(t *testing.T) {
+	data := []byte(`{
+  "name":"x","version":"0.1.0","coda":"^0.1.0",
+  "provides":{"notifications":{"slack":{}}}
+}`)
+	var warn bytes.Buffer
+	if _, err := Parse(data, &warn); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !strings.Contains(warn.String(), `unknown provides key "notifications"`) {
+		t.Fatalf("warn missing: %q", warn.String())
+	}
+}

--- a/internal/plugin/mcp.go
+++ b/internal/plugin/mcp.go
@@ -100,7 +100,7 @@ type rpcError struct {
 
 type rpcResponse struct {
 	JSONRPC string          `json:"jsonrpc"`
-	ID      json.RawMessage `json:"id,omitempty"`
+	ID      json.RawMessage `json:"id"`
 	Result  any             `json:"result,omitempty"`
 	Error   *rpcError       `json:"error,omitempty"`
 }
@@ -134,11 +134,19 @@ func (s *MCPServer) Serve(ctx context.Context, in io.Reader, out io.Writer) erro
 func (s *MCPServer) handle(ctx context.Context, line []byte) *rpcResponse {
 	var req rpcRequest
 	if err := json.Unmarshal(line, &req); err != nil {
-		return &rpcResponse{JSONRPC: "2.0", Error: &rpcError{Code: ErrParse, Message: "parse error: " + err.Error()}}
+		return &rpcResponse{JSONRPC: "2.0", ID: json.RawMessage("null"), Error: &rpcError{Code: ErrParse, Message: "parse error: " + err.Error()}}
 	}
 	if req.JSONRPC != "2.0" {
-		return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: ErrInvalidRequest, Message: "jsonrpc must be \"2.0\""}}
+		id := req.ID
+		if len(id) == 0 {
+			id = json.RawMessage("null")
+		}
+		return &rpcResponse{JSONRPC: "2.0", ID: id, Error: &rpcError{Code: ErrInvalidRequest, Message: "jsonrpc must be \"2.0\""}}
 	}
+	// JSON-RPC 2.0 notifications (no id field) get no response. An
+	// explicit `"id": null` is a request, not a notification — but
+	// MCP tooling never sends that, so treating both as notifications
+	// is acceptable for now.
 	if len(req.ID) == 0 {
 		return nil
 	}

--- a/internal/plugin/mcp.go
+++ b/internal/plugin/mcp.go
@@ -1,0 +1,252 @@
+package plugin
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"sort"
+)
+
+// JSON-RPC 2.0 error codes used by the MCP server.
+const (
+	ErrParse          = -32700
+	ErrInvalidRequest = -32600
+	ErrMethodNotFound = -32601
+	ErrInvalidParams  = -32602
+	ErrInternal       = -32603
+)
+
+// MCPProtocolVersion is the version reported by initialize. Mirrors
+// the MCP 2024-11-05 protocol level which is what most clients
+// negotiate today.
+const MCPProtocolVersion = "2024-11-05"
+
+// MCPServerName and MCPServerVersion identify the host in the
+// initialize response.
+const (
+	MCPServerName    = "coda"
+	MCPServerVersion = "0.1.0"
+)
+
+// MCPServer is a stdio JSON-RPC 2.0 server that exposes
+// plugin-declared tools through the three Model Context Protocol
+// methods initialize, tools/list, and tools/call.
+type MCPServer struct {
+	Tools []MCPToolEntry
+}
+
+// MCPToolEntry is a public summary of a registered MCP tool.
+type MCPToolEntry struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"inputSchema,omitempty"`
+	Plugin      string         `json:"-"`
+	Command     []string       `json:"-"`
+	Root        string         `json:"-"`
+}
+
+// NewMCPServer constructs a server from the loaded plugins. A
+// duplicate tool name across plugins is an error.
+func NewMCPServer(plugins []Plugin) (*MCPServer, error) {
+	seen := map[string]string{}
+	tools := make([]MCPToolEntry, 0)
+	for _, p := range plugins {
+		names := make([]string, 0, len(p.Manifest.Provides.MCPTools))
+		for n := range p.Manifest.Provides.MCPTools {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if existing, ok := seen[name]; ok {
+				return nil, fmt.Errorf("plugin %s: mcp tool %q already registered by plugin %s", p.Manifest.Name, name, existing)
+			}
+			seen[name] = p.Manifest.Name
+			t := p.Manifest.Provides.MCPTools[name]
+			if len(t.Command) == 0 {
+				return nil, fmt.Errorf("plugin %s: mcp tool %q: command is required", p.Manifest.Name, name)
+			}
+			tools = append(tools, MCPToolEntry{
+				Name:        name,
+				Description: t.Description,
+				InputSchema: t.InputSchema,
+				Plugin:      p.Manifest.Name,
+				Command:     append([]string(nil), t.Command...),
+				Root:        p.Root,
+			})
+		}
+	}
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+	return &MCPServer{Tools: tools}, nil
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+// Serve reads newline-delimited JSON-RPC 2.0 requests from in,
+// writes responses to out. It returns when in is exhausted or ctx
+// is cancelled.
+func (s *MCPServer) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	enc := json.NewEncoder(out)
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		resp := s.handle(ctx, line)
+		if resp == nil {
+			continue
+		}
+		if err := enc.Encode(resp); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+func (s *MCPServer) handle(ctx context.Context, line []byte) *rpcResponse {
+	var req rpcRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		return &rpcResponse{JSONRPC: "2.0", Error: &rpcError{Code: ErrParse, Message: "parse error: " + err.Error()}}
+	}
+	if req.JSONRPC != "2.0" {
+		return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: ErrInvalidRequest, Message: "jsonrpc must be \"2.0\""}}
+	}
+	if len(req.ID) == 0 {
+		return nil
+	}
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req)
+	case "tools/list":
+		return s.handleToolsList(req)
+	case "tools/call":
+		return s.handleToolsCall(ctx, req)
+	default:
+		return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: ErrMethodNotFound, Message: "method not found: " + req.Method}}
+	}
+}
+
+func (s *MCPServer) handleInitialize(req rpcRequest) *rpcResponse {
+	result := map[string]any{
+		"protocolVersion": MCPProtocolVersion,
+		"capabilities": map[string]any{
+			"tools": map[string]any{},
+		},
+		"serverInfo": map[string]any{
+			"name":    MCPServerName,
+			"version": MCPServerVersion,
+		},
+	}
+	return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: result}
+}
+
+func (s *MCPServer) handleToolsList(req rpcRequest) *rpcResponse {
+	out := make([]map[string]any, 0, len(s.Tools))
+	for _, t := range s.Tools {
+		entry := map[string]any{"name": t.Name}
+		if t.Description != "" {
+			entry["description"] = t.Description
+		}
+		if t.InputSchema != nil {
+			entry["inputSchema"] = t.InputSchema
+		}
+		out = append(out, entry)
+	}
+	return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]any{"tools": out}}
+}
+
+func (s *MCPServer) handleToolsCall(ctx context.Context, req rpcRequest) *rpcResponse {
+	var params struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: ErrInvalidParams, Message: "invalid params: " + err.Error()}}
+		}
+	}
+	if params.Name == "" {
+		return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: ErrInvalidParams, Message: "tools/call requires \"name\""}}
+	}
+	tool := s.findTool(params.Name)
+	if tool == nil {
+		return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: ErrInvalidParams, Message: "unknown tool: " + params.Name}}
+	}
+	args := params.Arguments
+	if len(args) == 0 {
+		args = []byte("{}")
+	}
+	stdout, callErr := tool.run(ctx, args)
+	if callErr != nil {
+		result := map[string]any{
+			"content": []map[string]any{{"type": "text", "text": callErr.Error()}},
+			"isError": true,
+		}
+		return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: result}
+	}
+	result := map[string]any{
+		"content": []map[string]any{{"type": "text", "text": string(stdout)}},
+		"isError": false,
+	}
+	return &rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: result}
+}
+
+func (s *MCPServer) findTool(name string) *MCPToolEntry {
+	for i := range s.Tools {
+		if s.Tools[i].Name == name {
+			return &s.Tools[i]
+		}
+	}
+	return nil
+}
+
+func (t *MCPToolEntry) run(ctx context.Context, stdin []byte) ([]byte, error) {
+	if len(t.Command) == 0 {
+		return nil, errors.New("tool command empty")
+	}
+	argv := append([]string(nil), t.Command...)
+	if !filepath.IsAbs(argv[0]) {
+		argv[0] = filepath.Join(t.Root, argv[0])
+	}
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Stdin = bytes.NewReader(stdin)
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		msg := errBuf.String()
+		if msg == "" {
+			msg = out.String()
+		}
+		return nil, fmt.Errorf("tool %s: %w: %s", t.Name, err, msg)
+	}
+	return out.Bytes(), nil
+}

--- a/internal/plugin/mcp_test.go
+++ b/internal/plugin/mcp_test.go
@@ -141,6 +141,13 @@ func TestMCP_ParseError(t *testing.T) {
 	if int(errObj["code"].(float64)) != ErrParse {
 		t.Fatalf("code=%v", errObj["code"])
 	}
+	id, ok := resp[0]["id"]
+	if !ok {
+		t.Fatalf("parse-error response must include id field per JSON-RPC 2.0; missing")
+	}
+	if id != nil {
+		t.Fatalf("parse-error id should be null, got %v", id)
+	}
 }
 
 func TestMCP_MethodNotFound(t *testing.T) {

--- a/internal/plugin/mcp_test.go
+++ b/internal/plugin/mcp_test.go
@@ -1,0 +1,174 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newMCPFixture(t *testing.T) *MCPServer {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	echo := filepath.Join(binDir, "echo")
+	if err := os.WriteFile(echo, []byte("#!/bin/sh\ncat\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugins := []Plugin{{
+		Root: root,
+		Manifest: Manifest{
+			Name: "demo",
+			Provides: Provides{
+				MCPTools: map[string]MCPTool{
+					"echo": {
+						Description: "echo back stdin",
+						InputSchema: map[string]any{"type": "object"},
+						Command:     []string{"bin/echo"},
+					},
+				},
+			},
+		},
+	}}
+	srv, err := NewMCPServer(plugins)
+	if err != nil {
+		t.Fatalf("NewMCPServer: %v", err)
+	}
+	return srv
+}
+
+func roundTrip(t *testing.T, srv *MCPServer, in string) []map[string]any {
+	t.Helper()
+	var out bytes.Buffer
+	if err := srv.Serve(context.Background(), strings.NewReader(in), &out); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	var got []map[string]any
+	dec := json.NewDecoder(&out)
+	for dec.More() {
+		var m map[string]any
+		if err := dec.Decode(&m); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		got = append(got, m)
+	}
+	return got
+}
+
+func TestMCP_Initialize(t *testing.T) {
+	srv := newMCPFixture(t)
+	resp := roundTrip(t, srv, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`+"\n")
+	if len(resp) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resp))
+	}
+	r := resp[0]
+	if r["jsonrpc"] != "2.0" || r["id"].(float64) != 1 {
+		t.Fatalf("envelope: %+v", r)
+	}
+	result := r["result"].(map[string]any)
+	if result["protocolVersion"] != MCPProtocolVersion {
+		t.Fatalf("protocolVersion=%v", result["protocolVersion"])
+	}
+	info := result["serverInfo"].(map[string]any)
+	if info["name"] != MCPServerName {
+		t.Fatalf("serverInfo.name=%v", info["name"])
+	}
+}
+
+func TestMCP_ToolsList(t *testing.T) {
+	srv := newMCPFixture(t)
+	resp := roundTrip(t, srv, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`+"\n")
+	if len(resp) != 1 {
+		t.Fatalf("got %d responses", len(resp))
+	}
+	tools := resp[0]["result"].(map[string]any)["tools"].([]any)
+	if len(tools) != 1 {
+		t.Fatalf("tools=%+v", tools)
+	}
+	first := tools[0].(map[string]any)
+	if first["name"] != "echo" {
+		t.Fatalf("tool name=%v", first["name"])
+	}
+	if first["description"] != "echo back stdin" {
+		t.Fatalf("description=%v", first["description"])
+	}
+}
+
+func TestMCP_ToolsCall(t *testing.T) {
+	srv := newMCPFixture(t)
+	resp := roundTrip(t, srv,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"hi":"there"}}}`+"\n")
+	if len(resp) != 1 {
+		t.Fatalf("got %d responses", len(resp))
+	}
+	result := resp[0]["result"].(map[string]any)
+	if result["isError"].(bool) {
+		t.Fatalf("isError=true: %+v", result)
+	}
+	content := result["content"].([]any)
+	first := content[0].(map[string]any)
+	text := first["text"].(string)
+	if !strings.Contains(text, `"hi":"there"`) {
+		t.Fatalf("text=%q", text)
+	}
+}
+
+func TestMCP_ToolsCall_Unknown(t *testing.T) {
+	srv := newMCPFixture(t)
+	resp := roundTrip(t, srv,
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"nope"}}`+"\n")
+	if len(resp) != 1 {
+		t.Fatalf("got %d responses", len(resp))
+	}
+	errObj := resp[0]["error"].(map[string]any)
+	if int(errObj["code"].(float64)) != ErrInvalidParams {
+		t.Fatalf("code=%v", errObj["code"])
+	}
+}
+
+func TestMCP_ParseError(t *testing.T) {
+	srv := newMCPFixture(t)
+	resp := roundTrip(t, srv, "not json\n")
+	if len(resp) != 1 {
+		t.Fatalf("got %d responses", len(resp))
+	}
+	errObj := resp[0]["error"].(map[string]any)
+	if int(errObj["code"].(float64)) != ErrParse {
+		t.Fatalf("code=%v", errObj["code"])
+	}
+}
+
+func TestMCP_MethodNotFound(t *testing.T) {
+	srv := newMCPFixture(t)
+	resp := roundTrip(t, srv, `{"jsonrpc":"2.0","id":5,"method":"prompts/list"}`+"\n")
+	if len(resp) != 1 {
+		t.Fatalf("got %d responses", len(resp))
+	}
+	errObj := resp[0]["error"].(map[string]any)
+	if int(errObj["code"].(float64)) != ErrMethodNotFound {
+		t.Fatalf("code=%v", errObj["code"])
+	}
+}
+
+func TestMCP_NotificationNoResponse(t *testing.T) {
+	srv := newMCPFixture(t)
+	resp := roundTrip(t, srv, `{"jsonrpc":"2.0","method":"notifications/initialized"}`+"\n")
+	if len(resp) != 0 {
+		t.Fatalf("expected no response for notification, got %+v", resp)
+	}
+}
+
+func TestMCP_DuplicateToolName(t *testing.T) {
+	plugins := []Plugin{
+		{Root: t.TempDir(), Manifest: Manifest{Name: "a", Provides: Provides{MCPTools: map[string]MCPTool{"x": {Command: []string{"true"}}}}}},
+		{Root: t.TempDir(), Manifest: Manifest{Name: "b", Provides: Provides{MCPTools: map[string]MCPTool{"x": {Command: []string{"true"}}}}}},
+	}
+	if _, err := NewMCPServer(plugins); err == nil {
+		t.Fatal("expected duplicate-tool error")
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,1 +1,21 @@
+// Package plugin implements coda's plugin host: manifest parsing,
+// discovery, subprocess providers, hook dispatch, command registration,
+// and the stdio MCP server. It is the unblocking primitive that makes
+// the otherwise empty ProviderRegistry usable.
+//
+// A plugin lives in a directory under $XDG_CONFIG_HOME/coda/plugins
+// (overridable via $CODA_PLUGINS_DIR) and ships a plugin.json
+// manifest. Manifests declare four optional contribution kinds:
+// commands, hooks, providers, and mcp_tools. Each contribution has
+// an executable artifact in the plugin dir; coda dispatches via
+// os/exec with explicit argv slices (no shell sourcing).
 package plugin
+
+// Plugin is a parsed manifest plus the absolute path to the plugin's
+// root directory. Loader returns []Plugin; consumers (provider
+// registry, command dispatcher, MCP server, hook runner) all key off
+// of these values.
+type Plugin struct {
+	Manifest Manifest
+	Root     string
+}

--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -1,0 +1,167 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/evanstern/coda/internal/session"
+)
+
+// SubprocessProvider implements session.Provider by spawning a plugin
+// executable for each method. The provider exec contract is published
+// at docs/plugin-contracts/providers.md.
+type SubprocessProvider struct {
+	Name string
+	Exec string
+	Root string
+
+	ctx context.Context
+}
+
+// NewSubprocessProvider returns a provider rooted at root that runs
+// exec (an absolute path or a path relative to root). name is used in
+// error messages and the --agent flag.
+func NewSubprocessProvider(name, root, execPath string) *SubprocessProvider {
+	full := execPath
+	if !filepath.IsAbs(full) {
+		full = filepath.Join(root, execPath)
+	}
+	return &SubprocessProvider{
+		Name: name,
+		Exec: full,
+		Root: root,
+		ctx:  context.Background(),
+	}
+}
+
+// WithContext returns a copy of p that uses ctx for subprocess
+// lifetime control.
+func (p *SubprocessProvider) WithContext(ctx context.Context) *SubprocessProvider {
+	cp := *p
+	cp.ctx = ctx
+	return &cp
+}
+
+func (p *SubprocessProvider) command(args ...string) *exec.Cmd {
+	ctx := p.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, p.Exec, args...)
+	return cmd
+}
+
+func (p *SubprocessProvider) runJSON(stdin []byte, args ...string) ([]byte, error) {
+	cmd := p.command(args...)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = strings.TrimSpace(stdout.String())
+		}
+		return nil, fmt.Errorf("plugin %s %s: %w: %s", p.Name, args[0], err, msg)
+	}
+	return stdout.Bytes(), nil
+}
+
+// Start spawns "<exec> start --agent=<name>" with the agent config as
+// JSON on stdin. Stdout's trimmed first line is taken as the session
+// ID.
+func (p *SubprocessProvider) Start(agent session.Agent, config session.ProviderConfig) (string, error) {
+	cfg, err := json.Marshal(config)
+	if err != nil {
+		return "", fmt.Errorf("marshal config: %w", err)
+	}
+	out, err := p.runJSON(cfg, "start", "--agent="+agent.Name)
+	if err != nil {
+		return "", err
+	}
+	id := strings.TrimSpace(string(out))
+	if id == "" {
+		return "", fmt.Errorf("plugin %s start: empty session id", p.Name)
+	}
+	return id, nil
+}
+
+// Stop spawns "<exec> stop <sessionID>". Non-zero exit becomes an
+// error.
+func (p *SubprocessProvider) Stop(sessionID string) error {
+	_, err := p.runJSON(nil, "stop", sessionID)
+	return err
+}
+
+// Deliver spawns "<exec> deliver <sessionID>" with the message JSON
+// on stdin. The plugin must respond with {"delivered": bool}.
+func (p *SubprocessProvider) Deliver(sessionID string, msg session.Message) (bool, error) {
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return false, fmt.Errorf("marshal message: %w", err)
+	}
+	out, err := p.runJSON(body, "deliver", sessionID)
+	if err != nil {
+		return false, err
+	}
+	var resp struct {
+		Delivered bool `json:"delivered"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(out), &resp); err != nil {
+		return false, fmt.Errorf("plugin %s deliver: parse response: %w", p.Name, err)
+	}
+	return resp.Delivered, nil
+}
+
+// Health spawns "<exec> health <sessionID>" and parses the
+// {state, healthy, detail} JSON.
+func (p *SubprocessProvider) Health(sessionID string) (session.Status, error) {
+	out, err := p.runJSON(nil, "health", sessionID)
+	if err != nil {
+		return session.Status{}, err
+	}
+	var s session.Status
+	if err := json.Unmarshal(bytes.TrimSpace(out), &s); err != nil {
+		return session.Status{}, fmt.Errorf("plugin %s health: parse response: %w", p.Name, err)
+	}
+	return s, nil
+}
+
+// Output spawns "<exec> output <sessionID> [--since=<rfc3339>]" and
+// parses a JSON array of session.Message.
+func (p *SubprocessProvider) Output(sessionID string, since *time.Time) ([]session.Message, error) {
+	args := []string{"output", sessionID}
+	if since != nil {
+		args = append(args, "--since="+since.UTC().Format(time.RFC3339Nano))
+	}
+	out, err := p.runJSON(nil, args...)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var msgs []session.Message
+	if err := json.Unmarshal(trimmed, &msgs); err != nil {
+		return nil, fmt.Errorf("plugin %s output: parse response: %w", p.Name, err)
+	}
+	return msgs, nil
+}
+
+// Attach spawns "<exec> attach <sessionID>". Non-zero exit becomes an
+// error.
+func (p *SubprocessProvider) Attach(sessionID string) error {
+	_, err := p.runJSON(nil, "attach", sessionID)
+	return err
+}
+
+var _ session.Provider = (*SubprocessProvider)(nil)

--- a/internal/plugin/provider_test.go
+++ b/internal/plugin/provider_test.go
@@ -1,0 +1,161 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evanstern/coda/internal/session"
+)
+
+func writeScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixtures unsupported on windows")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	script := "#!/bin/sh\n" + body
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const providerScriptBody = `set -e
+sub=$1
+shift
+case "$sub" in
+  start)
+    cat > "$LOG_DIR/start.in"
+    printf '%s\n' "$@" > "$LOG_DIR/start.args"
+    echo "sess-${LOG_TAG}"
+    ;;
+  stop)
+    printf '%s\n' "$@" > "$LOG_DIR/stop.args"
+    ;;
+  deliver)
+    cat > "$LOG_DIR/deliver.in"
+    printf '%s\n' "$@" > "$LOG_DIR/deliver.args"
+    printf '{"delivered":true}\n'
+    ;;
+  health)
+    printf '%s\n' "$@" > "$LOG_DIR/health.args"
+    printf '{"state":"running","healthy":true,"detail":"ok"}\n'
+    ;;
+  output)
+    printf '%s\n' "$@" > "$LOG_DIR/output.args"
+    printf '[{"ID":"m1","From":"x","To":"y","Type":"note","Body":"aGk=","CreatedAt":"2025-01-01T00:00:00Z"}]\n'
+    ;;
+  attach)
+    printf '%s\n' "$@" > "$LOG_DIR/attach.args"
+    ;;
+  fail)
+    echo "boom" >&2
+    exit 7
+    ;;
+esac
+`
+
+func newProviderFixture(t *testing.T, tag string) (*SubprocessProvider, string) {
+	root := t.TempDir()
+	logDir := t.TempDir()
+	bin := writeScript(t, filepath.Join(root, "bin"), "provider", providerScriptBody)
+	t.Setenv("LOG_DIR", logDir)
+	t.Setenv("LOG_TAG", tag)
+	p := NewSubprocessProvider("demo", root, bin)
+	return p, logDir
+}
+
+func TestSubprocessProvider_Start(t *testing.T) {
+	p, logDir := newProviderFixture(t, "start")
+	id, err := p.Start(session.Agent{Name: "ash"}, session.ProviderConfig{"foo": "bar"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if id != "sess-start" {
+		t.Fatalf("session id=%q", id)
+	}
+	args, _ := os.ReadFile(filepath.Join(logDir, "start.args"))
+	if !strings.Contains(string(args), "--agent=ash") {
+		t.Fatalf("args=%q", args)
+	}
+	in, _ := os.ReadFile(filepath.Join(logDir, "start.in"))
+	if !strings.Contains(string(in), `"foo":"bar"`) {
+		t.Fatalf("stdin=%q", in)
+	}
+}
+
+func TestSubprocessProvider_Stop(t *testing.T) {
+	p, logDir := newProviderFixture(t, "stop")
+	if err := p.Stop("sess-1"); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	args, _ := os.ReadFile(filepath.Join(logDir, "stop.args"))
+	if strings.TrimSpace(string(args)) != "sess-1" {
+		t.Fatalf("args=%q", args)
+	}
+}
+
+func TestSubprocessProvider_Deliver(t *testing.T) {
+	p, logDir := newProviderFixture(t, "del")
+	delivered, err := p.Deliver("sess-1", session.Message{ID: "m1"})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if !delivered {
+		t.Fatalf("expected delivered=true")
+	}
+	in, _ := os.ReadFile(filepath.Join(logDir, "deliver.in"))
+	if !strings.Contains(string(in), `"ID":"m1"`) {
+		t.Fatalf("stdin=%q", in)
+	}
+}
+
+func TestSubprocessProvider_Health(t *testing.T) {
+	p, _ := newProviderFixture(t, "health")
+	s, err := p.Health("sess-1")
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if s.State != "running" || !s.Healthy || s.Detail != "ok" {
+		t.Fatalf("status=%+v", s)
+	}
+}
+
+func TestSubprocessProvider_Output(t *testing.T) {
+	p, logDir := newProviderFixture(t, "output")
+	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	msgs, err := p.Output("sess-1", &since)
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].ID != "m1" {
+		t.Fatalf("msgs=%+v", msgs)
+	}
+	args, _ := os.ReadFile(filepath.Join(logDir, "output.args"))
+	if !strings.Contains(string(args), "--since=2025-01-01T00:00:00Z") {
+		t.Fatalf("args=%q", args)
+	}
+}
+
+func TestSubprocessProvider_Attach(t *testing.T) {
+	p, _ := newProviderFixture(t, "attach")
+	if err := p.Attach("sess-1"); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+}
+
+func TestSubprocessProvider_NonZeroExit(t *testing.T) {
+	root := t.TempDir()
+	bin := writeScript(t, filepath.Join(root, "bin"), "provider", "exit 7\n")
+	p := NewSubprocessProvider("demo", root, bin)
+	if err := p.Stop("sess-x"); err == nil {
+		t.Fatalf("expected error on non-zero exit")
+	}
+}


### PR DESCRIPTION
Implements v3 primitive #4: plugin host. The unblocking card —
ProviderRegistry is no longer always-empty.

Spec: docs/specs/171-plugin-host.md (in this PR)

## What ships
- internal/plugin/{manifest,loader,provider,hooks,mcp,command}.go
- coda mcp {serve,tools} subcommands
- defaultRegistry() loads plugins and registers their providers
- HookRunner replaces feature.localHookRunner (one-line wire change)
- Four plugin-contract docs

## Tests
- Unit tests for each subsystem (manifest parse matrix, loader edge
  cases, SubprocessProvider per-method args/JSON, HookRunner
  layering/sort/skip/warn, MCP initialize/list/call golden + error
  paths, reserved-name shadowing)
- Integration tests with fixture plugins (tempdir + real exec scripts)
- CLI E2E for `coda mcp serve` and `coda mcp tools` with a fixture
  plugin declaring an mcp_tool

## Acceptance gate
\`go build ./... && go vet ./... && go test ./... -count=1 -race\`  ✓
\`go mod tidy\` (no diff — no new deps)  ✓

## Out of scope (per spec)
- Plugin install/remove CLI (follow-up)
- HTTP MCP server
- v2 notifications/layouts
- Strict version-checking enforcement (warn-only for now)

Closes #171
Refs #166 milestone (v3 Go CLI), #173 (codaclaw provider — next).