### PR TITLE
Default MCP tool inputSchema in tools/list

### DIFF
--- a/internal/plugin/mcp.go
+++ b/internal/plugin/mcp.go
@@ -183,8 +183,13 @@ func (s *MCPServer) handleToolsList(req rpcRequest) *rpcResponse {
 		if t.Description != "" {
 			entry["description"] = t.Description
 		}
+		// MCP requires inputSchema on every tool. Default to an
+		// empty object schema when the manifest is silent so strict
+		// clients (e.g. opencode) don't reject the tools/list reply.
 		if t.InputSchema != nil {
 			entry["inputSchema"] = t.InputSchema
+		} else {
+			entry["inputSchema"] = map[string]any{"type": "object"}
 		}
 		out = append(out, entry)
 	}

--- a/internal/plugin/mcp_test.go
+++ b/internal/plugin/mcp_test.go
@@ -97,6 +97,44 @@ func TestMCP_ToolsList(t *testing.T) {
 	if first["description"] != "echo back stdin" {
 		t.Fatalf("description=%v", first["description"])
 	}
+	schema, ok := first["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputSchema missing or wrong type: %+v", first["inputSchema"])
+	}
+	if schema["type"] != "object" {
+		t.Fatalf("inputSchema.type=%v", schema["type"])
+	}
+}
+
+func TestMCP_ToolsList_DefaultsInputSchema(t *testing.T) {
+	plugins := []Plugin{{
+		Root: t.TempDir(),
+		Manifest: Manifest{
+			Name: "noschema",
+			Provides: Provides{
+				MCPTools: map[string]MCPTool{
+					"bare": {
+						Description: "tool with no declared schema",
+						Command:     []string{"bin/whatever"},
+					},
+				},
+			},
+		},
+	}}
+	srv, err := NewMCPServer(plugins)
+	if err != nil {
+		t.Fatalf("NewMCPServer: %v", err)
+	}
+	resp := roundTrip(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`+"\n")
+	tools := resp[0]["result"].(map[string]any)["tools"].([]any)
+	first := tools[0].(map[string]any)
+	schema, ok := first["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputSchema missing for tool with no declared schema: %+v", first)
+	}
+	if schema["type"] != "object" {
+		t.Fatalf("default inputSchema.type=%v, want object", schema["type"])
+	}
 }
 
 func TestMCP_ToolsCall(t *testing.T) {


### PR DESCRIPTION
## Summary

opencode rejects \`coda-v3\` MCP connections at handshake because
\`tools/list\` returns tools without \`inputSchema\`. The MCP spec
requires it; opencode validates with a zod schema where it's a
required object. Our smoke fixture (\`~/.config/coda/plugins/coda-hello/\`)
doesn't declare one, so v3 was silently broken in real clients
even though unit tests passed -- exactly the spec-compliant ≠
client-compatible trap from \`learnings/2026-04-27.md\`.

## Fix

\`internal/plugin/mcp.go\` \`handleToolsList\` now defaults
\`inputSchema\` to \`{\"type\":\"object\"}\` when the manifest is silent.
Existing plugins that declare a schema are unchanged.

## Verification

- \`go test ./...\` green
- Hand-run \`coda-dev mcp serve\` against the rebuilt binary now
  returns \`{\"name\":\"coda_hello\",\"description\":\"...\",\"inputSchema\":{\"type\":\"object\"}}\`
- Restarting opencode with the fixed binary should resolve the
  \`failed to get tools from client\` error in the log

## Tests

- Tightened \`TestMCP_ToolsList\` to assert \`inputSchema\` is present
- Added \`TestMCP_ToolsList_DefaultsInputSchema\` covering the
  no-schema path