### PR TITLE
SubprocessProvider.Attach: inherit stdio instead of buffering (#199)

### DIFF
--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -157,11 +158,17 @@ func (p *SubprocessProvider) Output(sessionID string, since *time.Time) ([]sessi
 	return msgs, nil
 }
 
-// Attach spawns "<exec> attach <sessionID>". Non-zero exit becomes an
-// error.
+// Attach spawns "<exec> attach <sessionID>" with the controlling
+// terminal's std streams inherited so the plugin's REPL or TUI can
+// drive the user's terminal directly. Non-zero exit becomes an
+// *exec.ExitError; stderr is not wrapped because it has already been
+// streamed to the terminal.
 func (p *SubprocessProvider) Attach(sessionID string) error {
-	_, err := p.runJSON(nil, "attach", sessionID)
-	return err
+	cmd := p.command("attach", sessionID)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 var _ session.Provider = (*SubprocessProvider)(nil)

--- a/internal/plugin/provider_test.go
+++ b/internal/plugin/provider_test.go
@@ -145,9 +145,13 @@ func TestSubprocessProvider_Output(t *testing.T) {
 }
 
 func TestSubprocessProvider_Attach(t *testing.T) {
-	p, _ := newProviderFixture(t, "attach")
+	p, logDir := newProviderFixture(t, "attach")
 	if err := p.Attach("sess-1"); err != nil {
 		t.Fatalf("Attach: %v", err)
+	}
+	args, _ := os.ReadFile(filepath.Join(logDir, "attach.args"))
+	if !strings.Contains(string(args), "sess-1") {
+		t.Fatalf("attach args missing sessionID: %q", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

`SubprocessProvider.Attach` was routing through `runJSON`, which captures stdout/stderr into `bytes.Buffer`s. That made interactive attach impossible — any provider's REPL output was swallowed before reaching the user's terminal.

Replaced with a direct exec path that inherits `os.Stdin`/`Stdout`/`Stderr` from the controlling terminal, matching the standard Go pattern for exec'd interactive TUIs (e.g. `git commit` opening `$EDITOR`).

## Why

Caught by Kit (codaclaw orch) on bus msg #41 while drafting the #173 (CodaClaw provider) spec. CodaClaw's attach is `pnpm run chat <agent>` — a stdin/stdout REPL into the agent's inbound.db. With the old `Attach` impl, none of that REPL traffic reaches the user. Blocks #173 attach implementation and any other provider that wants an interactive channel.

## Decisions

- **No TTY-detection fallback.** Inherit unconditionally. If stdin/stdout aren't a terminal, the plugin handles the EOF/non-TTY case itself — it's plugin business, not coda's.
- **No error-message wrapping** like runJSON does. `cmd.Run()` returns an `*exec.ExitError` with the exit code; wrapping with stderr text is wrong here because stderr already streamed to the terminal.
- **Keep runJSON for the other five methods.** Start/Stop/Deliver/Health/Output all want capture-and-parse. Attach is the only outlier.

## Test plan

- Existing `TestSubprocessProvider_Attach` still passes.
- Added `sess-1` argv assertion mirroring `TestSubprocessProvider_Output`.
- Manual verification via a mock provider script that streams output: pre-fix, output was buffered and discarded; post-fix, lines appear in the terminal.
- Full suite: \`go build ./... && go vet ./... && go test ./...\` clean.

## Files

- \`internal/plugin/provider.go\`: rewrite Attach
- \`internal/plugin/provider_test.go\`: add argv assertion

Closes #199