### PR TITLE
docs(providers): name the ProviderConfig key naming convention

### DIFF
--- a/docs/plugin-contracts/providers.md
+++ b/docs/plugin-contracts/providers.md
@@ -34,6 +34,32 @@ parses output from stdout. Non-zero exit codes become errors.
 
 `session.ProviderConfig` is an opaque `map[string]string`.
 
+### ProviderConfig key naming
+
+`ProviderConfig` is per-agent: each agent declares one provider and
+one config blob. The keys in that blob belong to exactly one
+provider's namespace, so collision across providers is impossible
+by construction.
+
+**Convention: use unprefixed keys.** A CodaClaw provider config
+uses `host_endpoint`, `image`, `mount_allowlist` — not
+`codaclaw_host`, `codaclaw_image`. The provider's identity is
+already implicit in the agent's `provider` field; restating it in
+every key is noise.
+
+Format notes:
+
+- Values are always strings. Structured types (lists, paths, ports)
+  serialize to strings — typically comma-separated for lists, with
+  whitespace around commas ignored.
+- Paths support `~/` expansion at the plugin layer; document the
+  expansion behavior per-key when relevant.
+- Names containing secrets (API keys, tokens) MUST refer to env
+  var names rather than embed the secret. `ProviderConfig`
+  serializes into `coda.db`; secrets do not belong there.
+  Convention: `<thing>_env` for env-var-name keys
+  (e.g. `anthropic_api_key_env: ANTHROPIC_API_KEY`).
+
 ## Error semantics
 
 - **Zero exit code** is success. Any other exit is an error; the


### PR DESCRIPTION
## Summary

Document the convention that `ProviderConfig` keys are unprefixed
(e.g. `host_endpoint`, not `codaclaw_host`). Per-agent
`ProviderConfig` has exactly one provider, so keys belong to one
provider's namespace by construction; collision is impossible.

Also documents three format conventions that surfaced during the
`#173` (CodaClaw provider) spec review:

- Values are always strings; structured types serialize (lists →
  comma-separated, whitespace tolerated)
- Paths support `~/` expansion at the plugin layer
- Secrets refer to env var names rather than embed the value
  (since `ProviderConfig` serializes into `coda.db`); convention
  is `<thing>_env`

## Why now

Promised to Kit during `evanstern/coda-codaclaw#1` review (the
`#173` spec). The convention is now load-bearing for whoever
writes the next provider plugin (`coda-opencode`, `coda-tmux`,
etc.) — recording it in the contract doc means they inherit it
without asking.

## What changed

One file: `docs/plugin-contracts/providers.md`. New
`### ProviderConfig key naming` subsection inserted between the
existing `map[string]string` line and the `## Error semantics`
section. Plain markdown, no behavior change.

## Refs

- `#201` — focus card filed for this work
- `evanstern/coda-codaclaw#1` — spec where the convention was
  decided