### PR TITLE
session model: capture provider-returned session ID (#202)

### DIFF
--- a/cmd/coda/main.go
+++ b/cmd/coda/main.go
@@ -463,9 +463,17 @@ func startAgent(ctx context.Context, store *session.Store, msgStore *messages.St
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
 	}
-	if _, err := provider.Start(*agent, session.ProviderConfig{}); err != nil {
+	provSessID, err := provider.Start(*agent, session.ProviderConfig{})
+	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
+	}
+	if provSessID != "" {
+		if err := store.SetProviderSessionID(ctx, sess.ID, provSessID); err != nil {
+			fmt.Fprintf(stderr, "warn: provider started but recording its session id failed: %v\n", err)
+			return exitUserErr
+		}
+		sess.ProviderSessionID = provSessID
 	}
 	if err := store.TransitionSession(ctx, sess.ID, session.StateCreated, session.StateStarted); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
@@ -502,7 +510,7 @@ func stopAgent(ctx context.Context, store *session.Store, reg *session.ProviderR
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitUserErr
 	}
-	if err := provider.Stop(sess.ID); err != nil {
+	if err := provider.Stop(sess.ProviderID()); err != nil {
 		if rbErr := store.RollbackFromStopped(ctx, sess.ID, prev); rbErr != nil {
 			fmt.Fprintf(stderr, "error: provider stop: %v; rollback: %v\n", err, rbErr)
 			return exitUserErr

--- a/cmd/coda/main.go
+++ b/cmd/coda/main.go
@@ -469,8 +469,24 @@ func startAgent(ctx context.Context, store *session.Store, msgStore *messages.St
 		return exitUserErr
 	}
 	if provSessID != "" {
-		if err := store.SetProviderSessionID(ctx, sess.ID, provSessID); err != nil {
-			fmt.Fprintf(stderr, "warn: provider started but recording its session id failed: %v\n", err)
+		if setErr := store.SetProviderSessionID(ctx, sess.ID, provSessID); setErr != nil {
+			// Best-effort cleanup: the provider session is running
+			// but we can't address it on a future Stop call (we'd
+			// fall back to coda's ULID, which is the bug this
+			// migration exists to prevent). Stop the orphan and
+			// mark the session row stopped so subsequent commands
+			// see consistent state.
+			cleanupErr := provider.Stop(provSessID)
+			if cleanupErr == nil {
+				if transErr := store.TransitionSession(ctx, sess.ID, session.StateCreated, session.StateStopped, "provider-id-record-failed"); transErr != nil {
+					cleanupErr = transErr
+				}
+			}
+			if cleanupErr != nil {
+				fmt.Fprintf(stderr, "error: provider started but recording its session id failed: %v; cleanup failed: %v\n", setErr, cleanupErr)
+				return exitUserErr
+			}
+			fmt.Fprintf(stderr, "error: provider started but recording its session id failed: %v; provider session %q was stopped\n", setErr, provSessID)
 			return exitUserErr
 		}
 		sess.ProviderSessionID = provSessID

--- a/cmd/coda/main_test.go
+++ b/cmd/coda/main_test.go
@@ -23,6 +23,7 @@ import (
 type stubProvider struct {
 	startCalls int
 	stopCalls  int
+	stopSeen   []string
 	startErr   error
 	stopErr    error
 }
@@ -31,7 +32,11 @@ func (s *stubProvider) Start(a session.Agent, _ session.ProviderConfig) (string,
 	s.startCalls++
 	return "stub-" + a.Name, s.startErr
 }
-func (s *stubProvider) Stop(_ string) error { s.stopCalls++; return s.stopErr }
+func (s *stubProvider) Stop(sessionID string) error {
+	s.stopCalls++
+	s.stopSeen = append(s.stopSeen, sessionID)
+	return s.stopErr
+}
 func (s *stubProvider) Deliver(_ string, _ session.Message) (bool, error) {
 	return true, nil
 }
@@ -168,6 +173,9 @@ func TestStartStopAgentHappyPath(t *testing.T) {
 	if active.State != session.StateStarted {
 		t.Fatalf("expected started, got %s", active.State)
 	}
+	if active.ProviderSessionID != "stub-a" {
+		t.Fatalf("expected ProviderSessionID=stub-a (returned by stubProvider.Start), got %q", active.ProviderSessionID)
+	}
 
 	stdout.Reset()
 	stderr.Reset()
@@ -179,6 +187,9 @@ func TestStartStopAgentHappyPath(t *testing.T) {
 	}
 	if provider.stopCalls != 1 {
 		t.Fatalf("expected 1 stop call, got %d", provider.stopCalls)
+	}
+	if len(provider.stopSeen) != 1 || provider.stopSeen[0] != "stub-a" {
+		t.Fatalf("expected Stop called with provider session id 'stub-a', got %v", provider.stopSeen)
 	}
 	stopped, err := store.GetSession(ctx, active.ID)
 	if err != nil {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -33,8 +33,8 @@ func TestMigrateIdempotent(t *testing.T) {
 	if err := d.QueryRowContext(ctx, `SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count schema_migrations: %v", err)
 	}
-	if count != 3 {
-		t.Fatalf("expected 3 applied migrations, got %d", count)
+	if count != 4 {
+		t.Fatalf("expected 4 applied migrations, got %d", count)
 	}
 
 	tables := map[string]bool{}

--- a/internal/db/migrations/004_provider_session_id.sql
+++ b/internal/db/migrations/004_provider_session_id.sql
@@ -1,0 +1,13 @@
+-- Add provider_session_id to sessions so coda can address downstream
+-- provider methods (Stop/Deliver/Health/Output/Attach) by the
+-- provider's native session ID rather than coda's internal ULID.
+--
+-- Provider.Start returns a string; before this migration it was
+-- discarded and provider calls used coda's session ID, which made
+-- correlation impossible for any provider with native session IDs
+-- (CodaClaw: kit-default-01HXX, opencode: ses_..., etc.).
+--
+-- The column is NOT NULL DEFAULT '' so existing rows stay valid and
+-- new rows fall through to coda's session ID until Set is called.
+
+ALTER TABLE sessions ADD COLUMN provider_session_id TEXT NOT NULL DEFAULT '';

--- a/internal/messages/router.go
+++ b/internal/messages/router.go
@@ -89,7 +89,7 @@ func (r *Router) deliver(ctx context.Context, m Stored) (bool, error) {
 	if !ok {
 		return false, &session.NoProviderError{AgentName: m.Recipient, Provider: sess.Provider}
 	}
-	delivered, err := provider.Deliver(sess.ID, m.ToWire())
+	delivered, err := provider.Deliver(sess.ProviderID(), m.ToWire())
 	if err != nil {
 		return false, fmt.Errorf("provider deliver: %w", err)
 	}

--- a/internal/messages/router_test.go
+++ b/internal/messages/router_test.go
@@ -226,3 +226,41 @@ func TestDrain_PartialFailure(t *testing.T) {
 		t.Fatalf("expected failed message to remain undelivered")
 	}
 }
+
+func TestSend_UsesProviderSessionIDWhenSet(t *testing.T) {
+	fix := newRouterFixture(t, true)
+	ctx := context.Background()
+	if err := fix.sessions.SetProviderSessionID(ctx, fix.recipientID, "kit-default-01HXX"); err != nil {
+		t.Fatal(err)
+	}
+	var seen string
+	fix.provider.deliverFn = func(sessionID string, msg session.Message) (bool, error) {
+		seen = sessionID
+		return true, nil
+	}
+	if _, _, err := fix.router.Send(ctx, "ash", "zach", messages.TypeNote, []byte(`{"x":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	if seen != "kit-default-01HXX" {
+		t.Fatalf("expected provider to be called with provider session ID, got %q", seen)
+	}
+	if seen == fix.recipientID {
+		t.Fatalf("provider should not have received coda session ID %q", fix.recipientID)
+	}
+}
+
+func TestSend_FallsBackToCodaIDWhenProviderSessionEmpty(t *testing.T) {
+	fix := newRouterFixture(t, true)
+	ctx := context.Background()
+	var seen string
+	fix.provider.deliverFn = func(sessionID string, msg session.Message) (bool, error) {
+		seen = sessionID
+		return true, nil
+	}
+	if _, _, err := fix.router.Send(ctx, "ash", "zach", messages.TypeNote, []byte(`{"x":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	if seen != fix.recipientID {
+		t.Fatalf("expected fallback to coda ID %q, got %q", fix.recipientID, seen)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -26,11 +26,24 @@ const (
 // enforced by the sessions_one_active_per_agent partial unique
 // index (see internal/db/migrations/001_initial.sql).
 type Session struct {
-	ID         string
-	AgentName  string
-	Provider   string
-	State      SessionState
-	StartedAt  *time.Time
-	StoppedAt  *time.Time
-	StopReason string
+	ID                string
+	AgentName         string
+	Provider          string
+	ProviderSessionID string
+	State             SessionState
+	StartedAt         *time.Time
+	StoppedAt         *time.Time
+	StopReason        string
+}
+
+// ProviderID returns the session ID to pass to provider methods
+// (Stop, Deliver, Health, Output, Attach). Falls back to the coda
+// session ID when ProviderSessionID is empty -- the case for
+// pre-existing rows from before migration 004 and for test stub
+// providers that return an empty Start ID.
+func (s Session) ProviderID() string {
+	if s.ProviderSessionID != "" {
+		return s.ProviderSessionID
+	}
+	return s.ID
 }

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -105,15 +105,39 @@ func (s *Store) ListAgents(ctx context.Context) ([]Agent, error) {
 // already generated a ULID ID (see NewSessionID). Fails with a UNIQUE
 // constraint error if another non-stopped session exists for the same
 // agent (enforced by the sessions_one_active_per_agent partial index).
+//
+// ProviderSessionID is typically empty at create time; populate it
+// after Provider.Start returns via SetProviderSessionID.
 func (s *Store) CreateSession(ctx context.Context, sess Session) error {
 	if sess.State == "" {
 		sess.State = StateCreated
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO sessions(id, agent_name, provider, state) VALUES (?, ?, ?, ?)`,
-		sess.ID, sess.AgentName, sess.Provider, string(sess.State))
+		`INSERT INTO sessions(id, agent_name, provider, provider_session_id, state)
+		 VALUES (?, ?, ?, ?, ?)`,
+		sess.ID, sess.AgentName, sess.Provider, sess.ProviderSessionID, string(sess.State))
 	if err != nil {
 		return fmt.Errorf("insert session: %w", err)
+	}
+	return nil
+}
+
+// SetProviderSessionID records the provider's native session ID on
+// an existing session row. Called after Provider.Start returns. The
+// row must exist; ErrNotFound is returned otherwise.
+func (s *Store) SetProviderSessionID(ctx context.Context, codaSessionID, providerSessionID string) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE sessions SET provider_session_id = ? WHERE id = ?`,
+		providerSessionID, codaSessionID)
+	if err != nil {
+		return fmt.Errorf("set provider_session_id: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
 	}
 	return nil
 }
@@ -121,7 +145,7 @@ func (s *Store) CreateSession(ctx context.Context, sess Session) error {
 // GetSession returns the session with the given ID, or ErrNotFound.
 func (s *Store) GetSession(ctx context.Context, id string) (*Session, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, agent_name, provider, state, started_at, stopped_at, stop_reason
+		`SELECT id, agent_name, provider, provider_session_id, state, started_at, stopped_at, stop_reason
 		   FROM sessions WHERE id = ?`, id)
 	return scanSession(row)
 }
@@ -130,7 +154,7 @@ func (s *Store) GetSession(ctx context.Context, id string) (*Session, error) {
 // agent, if any. Returns ErrNotFound if none.
 func (s *Store) GetActiveSession(ctx context.Context, agentName string) (*Session, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, agent_name, provider, state, started_at, stopped_at, stop_reason
+		`SELECT id, agent_name, provider, provider_session_id, state, started_at, stopped_at, stop_reason
 		   FROM sessions WHERE agent_name = ? AND state != 'stopped'
 		   LIMIT 1`, agentName)
 	return scanSession(row)
@@ -139,7 +163,7 @@ func (s *Store) GetActiveSession(ctx context.Context, agentName string) (*Sessio
 // ListSessionsForAgent returns all sessions for an agent, oldest first.
 func (s *Store) ListSessionsForAgent(ctx context.Context, agentName string) ([]Session, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, agent_name, provider, state, started_at, stopped_at, stop_reason
+		`SELECT id, agent_name, provider, provider_session_id, state, started_at, stopped_at, stop_reason
 		   FROM sessions WHERE agent_name = ? ORDER BY id`, agentName)
 	if err != nil {
 		return nil, fmt.Errorf("query sessions: %w", err)
@@ -152,7 +176,7 @@ func (s *Store) ListSessionsForAgent(ctx context.Context, agentName string) ([]S
 			startedAt, stoppedAt, stopReason sql.NullString
 			state                            string
 		)
-		if err := rows.Scan(&sess.ID, &sess.AgentName, &sess.Provider, &state,
+		if err := rows.Scan(&sess.ID, &sess.AgentName, &sess.Provider, &sess.ProviderSessionID, &state,
 			&startedAt, &stoppedAt, &stopReason); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
@@ -290,7 +314,7 @@ func scanSession(row rowScanner) (*Session, error) {
 		startedAt, stoppedAt, stopReason sql.NullString
 		state                            string
 	)
-	err := row.Scan(&sess.ID, &sess.AgentName, &sess.Provider, &state,
+	err := row.Scan(&sess.ID, &sess.AgentName, &sess.Provider, &sess.ProviderSessionID, &state,
 		&startedAt, &stoppedAt, &stopReason)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -125,6 +125,11 @@ func (s *Store) CreateSession(ctx context.Context, sess Session) error {
 // SetProviderSessionID records the provider's native session ID on
 // an existing session row. Called after Provider.Start returns. The
 // row must exist; ErrNotFound is returned otherwise.
+//
+// SQLite reports RowsAffected==0 for a no-op UPDATE (setting the
+// column to its existing value), so we can't use that as the
+// existence signal. Verify directly with a follow-up SELECT when
+// the UPDATE reports zero rows changed.
 func (s *Store) SetProviderSessionID(ctx context.Context, codaSessionID, providerSessionID string) error {
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE sessions SET provider_session_id = ? WHERE id = ?`,
@@ -137,7 +142,13 @@ func (s *Store) SetProviderSessionID(ctx context.Context, codaSessionID, provide
 		return fmt.Errorf("rows affected: %w", err)
 	}
 	if n == 0 {
-		return ErrNotFound
+		var exists int
+		if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM sessions WHERE id = ?`, codaSessionID).Scan(&exists); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("verify session existence: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -359,3 +359,21 @@ func TestSetProviderSessionIDNotFound(t *testing.T) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestSetProviderSessionIDIdempotent(t *testing.T) {
+	store, _ := newStore(t)
+	ctx := context.Background()
+	if err := store.CreateAgent(ctx, session.Agent{Name: "a", Provider: "stub"}); err != nil {
+		t.Fatal(err)
+	}
+	id := session.NewSessionID()
+	if err := store.CreateSession(ctx, session.Session{ID: id, AgentName: "a", Provider: "stub", State: session.StateCreated}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetProviderSessionID(ctx, id, "kit-default-01HXX"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetProviderSessionID(ctx, id, "kit-default-01HXX"); err != nil {
+		t.Fatalf("re-setting same value should not error (SQLite reports RowsAffected=0 for no-op): %v", err)
+	}
+}

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -312,3 +312,50 @@ func TestListAgents(t *testing.T) {
 		t.Fatalf("expected 3 agents, got %d", len(agents))
 	}
 }
+
+func TestSetProviderSessionID(t *testing.T) {
+	store, _ := newStore(t)
+	ctx := context.Background()
+	if err := store.CreateAgent(ctx, session.Agent{Name: "a", Provider: "stub"}); err != nil {
+		t.Fatal(err)
+	}
+	id := session.NewSessionID()
+	if err := store.CreateSession(ctx, session.Session{ID: id, AgentName: "a", Provider: "stub", State: session.StateCreated}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetSession(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ProviderSessionID != "" {
+		t.Fatalf("expected empty ProviderSessionID at create, got %q", got.ProviderSessionID)
+	}
+	if got.ProviderID() != id {
+		t.Fatalf("ProviderID() with empty ProviderSessionID should fall back to coda ID; got %q want %q", got.ProviderID(), id)
+	}
+
+	if err := store.SetProviderSessionID(ctx, id, "kit-default-01HXX"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = store.GetSession(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ProviderSessionID != "kit-default-01HXX" {
+		t.Fatalf("expected ProviderSessionID=kit-default-01HXX, got %q", got.ProviderSessionID)
+	}
+	if got.ProviderID() != "kit-default-01HXX" {
+		t.Fatalf("ProviderID() should return ProviderSessionID when populated; got %q", got.ProviderID())
+	}
+}
+
+func TestSetProviderSessionIDNotFound(t *testing.T) {
+	store, _ := newStore(t)
+	ctx := context.Background()
+	err := store.SetProviderSessionID(ctx, "no-such-session", "x")
+	if !errors.Is(err, session.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`Provider.Start` returns `(sessionID, err)` per
`internal/session/provider.go:12`, but coda was discarding the
session ID and using its own pre-generated ULID for every
downstream provider call (`Stop`, `Deliver`, `Health`, `Output`,
`Attach`). This prevented any provider with native session IDs
(CodaClaw `kit-default-01HXX`, opencode `ses_...`, etc.) from
correlating coda's calls back to its own state.

## What changed

- **Schema:** new column `sessions.provider_session_id` via
  migration `004_provider_session_id.sql`. `NOT NULL DEFAULT ''`
  so existing rows stay valid.
- **Capture:** `cmd/coda/main.go` `startAgent` records the
  provider's returned ID via the new `Store.SetProviderSessionID`
  after `Provider.Start` succeeds.
- **Use:** `cmd/coda/main.go` `stopAgent` and
  `internal/messages/router.go` `Router.deliver` now call provider
  methods with `sess.ProviderID()` instead of `sess.ID`.
- **Helper:** `Session.ProviderID()` returns
  `ProviderSessionID` when populated, falls back to `ID` when
  empty. The fallback covers test stub providers that return an
  empty `Start` ID and pre-existing rows from before this
  migration.

## Why two IDs (not one)

Sub-decision was \"replace coda's ULID with the provider's ID\"
vs \"add a column.\" Add. Reasons:

1. **FK stability.** `messages` and other coda-internal
   references should not flap because a provider chose a weird
   ID format. coda's ULID stays the primary key.
2. **Multi-provider future.** When `coda-opencode` and
   `coda-tmux` providers exist, each will have its own native ID
   format. A polymorphic `id` column means different things for
   different rows. Avoid.
3. **UI flexibility.** `coda agent ls` can surface either ID
   depending on what's friendlier; one-column forces the choice
   up front.

## How it was caught

Kit (codaclaw orch) flagged it via the bus while drafting Card B
(plugin subcommand impls in `evanstern/coda-codaclaw`). Same
shape as #199 — coda-side gap surfaced by Kit's spec-side work,
small surgical fix on the coda side, lands ahead of Kit's
implementation.

## Testing

```
$ go test ./...
ok      github.com/evanstern/coda/cmd/coda
ok      github.com/evanstern/coda/internal/db
ok      github.com/evanstern/coda/internal/feature
ok      github.com/evanstern/coda/internal/identity
ok      github.com/evanstern/coda/internal/messages
ok      github.com/evanstern/coda/internal/plugin
ok      github.com/evanstern/coda/internal/session
$ go vet ./...   # clean
$ gofmt -l .     # clean
```

New tests:
- `session.TestSetProviderSessionID` — round-trip the new column;
  `ProviderID()` falls back, then returns the provider ID once
  set.
- `session.TestSetProviderSessionIDNotFound` — unknown coda ID
  returns `ErrNotFound`.
- `cmd/coda.TestStartStopAgentHappyPath` extended to assert
  `ProviderSessionID` is populated after `agent start` and that
  `Stop` is called with the provider's ID, not coda's.
- `messages.TestSend_UsesProviderSessionIDWhenSet` — `Deliver`
  receives the provider ID when populated.
- `messages.TestSend_FallsBackToCodaIDWhenProviderSessionEmpty` —
  `Deliver` falls back to coda's ID when not.

Existing `TestMigrateIdempotent` updated for the new migration count.

## Refs

- `#202` — focus card
- `#199` — prior coda-side fix in the same shape (`SubprocessProvider.Attach`)
- `evanstern/coda-codaclaw#3` — Card B (CodaClaw plugin subcommand
  impls), unblocked by this