### PR TITLE
Provider.Output: opaque cursor protocol (#205)

### DIFF
--- a/cmd/coda/main_test.go
+++ b/cmd/coda/main_test.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/evanstern/coda/internal/db"
 	"github.com/evanstern/coda/internal/messages"
@@ -43,7 +42,7 @@ func (s *stubProvider) Deliver(_ string, _ session.Message) (bool, error) {
 func (s *stubProvider) Health(_ string) (session.Status, error) {
 	return session.Status{State: "running", Healthy: true}, nil
 }
-func (s *stubProvider) Output(_ string, _ *time.Time) ([]session.Message, error) {
+func (s *stubProvider) Output(_ string, _ string) ([]session.Message, error) {
 	return nil, nil
 }
 func (s *stubProvider) Attach(_ string) error { return nil }

--- a/docs/plugin-contracts/providers.md
+++ b/docs/plugin-contracts/providers.md
@@ -21,9 +21,16 @@ parses output from stdout. Non-zero exit codes become errors.
 
 The `--since=<cursor>` value is opaque to coda and plugin-defined.
 Each `session.Message` returned by `Output` may carry a `Cursor`
-field. Coda persists the most recent cursor from the response and
-echoes it back as `--since=` on the next call. An empty cursor (or
-omitted `--since`) means "from the beginning."
+field. `Output` responses are ordered: plugins MUST return messages
+in the same stream order they want cursor advancement to follow
+(typically oldest to newest). Coda does not compare, sort, or
+otherwise interpret cursor values. After a successful `Output`
+call, coda persists the `Cursor` from the last message in the
+returned array whose `Cursor` is non-empty, and echoes that exact
+value back as `--since=` on the next call. If no returned message
+has a non-empty `Cursor`, coda leaves the persisted cursor
+unchanged. An empty cursor (or omitted `--since`) means "from the
+beginning."
 
 ## JSON shapes
 

--- a/docs/plugin-contracts/providers.md
+++ b/docs/plugin-contracts/providers.md
@@ -14,8 +14,16 @@ parses output from stdout. Non-zero exit codes become errors.
 | `Stop(sessionID)`     | `stop <sessionID>`                  | (none)               | (none) — exit 0 on success                     |
 | `Deliver(sid, msg)`   | `deliver <sessionID>`               | message JSON         | `{"delivered": <bool>}`                        |
 | `Health(sid)`         | `health <sessionID>`                | (none)               | `{"State": "...", "Healthy": <bool>, "Detail": "..."}` |
-| `Output(sid, since?)` | `output <sessionID> [--since=<RFC3339>]` | (none)          | JSON array of `session.Message`                |
+| `Output(sid, since?)` | `output <sessionID> [--since=<cursor>]` | (none)          | JSON array of `session.Message`                |
 | `Attach(sid)`         | `attach <sessionID>`                | (none)               | (none) — exit 0 on success                     |
+
+## Cursor protocol
+
+The `--since=<cursor>` value is opaque to coda and plugin-defined.
+Each `session.Message` returned by `Output` may carry a `Cursor`
+field. Coda persists the most recent cursor from the response and
+echoes it back as `--since=` on the next call. An empty cursor (or
+omitted `--since`) means "from the beginning."
 
 ## JSON shapes
 
@@ -28,7 +36,8 @@ parses output from stdout. Non-zero exit codes become errors.
   "To": "agent-b",
   "Type": "note",
   "Body": "<base64-encoded bytes>",
-  "CreatedAt": "2025-01-01T00:00:00Z"
+  "CreatedAt": "2025-01-01T00:00:00Z",
+  "Cursor": "plugin-defined-opaque-value"
 }
 ```
 

--- a/internal/messages/router_test.go
+++ b/internal/messages/router_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/evanstern/coda/internal/db"
 	"github.com/evanstern/coda/internal/messages"
@@ -35,7 +34,7 @@ func (f *fakeProvider) Deliver(sessionID string, msg session.Message) (bool, err
 	return true, nil
 }
 func (f *fakeProvider) Health(_ string) (session.Status, error) { return session.Status{}, nil }
-func (f *fakeProvider) Output(_ string, _ *time.Time) ([]session.Message, error) {
+func (f *fakeProvider) Output(_ string, _ string) ([]session.Message, error) {
 	return nil, nil
 }
 func (f *fakeProvider) Attach(_ string) error { return nil }

--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/evanstern/coda/internal/session"
 )
@@ -136,12 +135,12 @@ func (p *SubprocessProvider) Health(sessionID string) (session.Status, error) {
 	return s, nil
 }
 
-// Output spawns "<exec> output <sessionID> [--since=<rfc3339>]" and
+// Output spawns "<exec> output <sessionID> [--since=<cursor>]" and
 // parses a JSON array of session.Message.
-func (p *SubprocessProvider) Output(sessionID string, since *time.Time) ([]session.Message, error) {
+func (p *SubprocessProvider) Output(sessionID string, since string) ([]session.Message, error) {
 	args := []string{"output", sessionID}
-	if since != nil {
-		args = append(args, "--since="+since.UTC().Format(time.RFC3339Nano))
+	if since != "" {
+		args = append(args, "--since="+since)
 	}
 	out, err := p.runJSON(nil, args...)
 	if err != nil {

--- a/internal/plugin/provider_test.go
+++ b/internal/plugin/provider_test.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/evanstern/coda/internal/session"
 )
@@ -50,7 +49,7 @@ case "$sub" in
     ;;
   output)
     printf '%s\n' "$@" > "$LOG_DIR/output.args"
-    printf '[{"ID":"m1","From":"x","To":"y","Type":"note","Body":"aGk=","CreatedAt":"2025-01-01T00:00:00Z"}]\n'
+    printf '[{"ID":"m1","From":"x","To":"y","Type":"note","Body":"aGk=","CreatedAt":"2025-01-01T00:00:00Z","Cursor":"seq:42"}]\n'
     ;;
   attach)
     printf '%s\n' "$@" > "$LOG_DIR/attach.args"
@@ -130,16 +129,18 @@ func TestSubprocessProvider_Health(t *testing.T) {
 
 func TestSubprocessProvider_Output(t *testing.T) {
 	p, logDir := newProviderFixture(t, "output")
-	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	msgs, err := p.Output("sess-1", &since)
+	msgs, err := p.Output("sess-1", "cursor-abc")
 	if err != nil {
 		t.Fatalf("Output: %v", err)
 	}
 	if len(msgs) != 1 || msgs[0].ID != "m1" {
 		t.Fatalf("msgs=%+v", msgs)
 	}
+	if msgs[0].Cursor != "seq:42" {
+		t.Fatalf("cursor=%q, want seq:42", msgs[0].Cursor)
+	}
 	args, _ := os.ReadFile(filepath.Join(logDir, "output.args"))
-	if !strings.Contains(string(args), "--since=2025-01-01T00:00:00Z") {
+	if !strings.Contains(string(args), "--since=cursor-abc") {
 		t.Fatalf("args=%q", args)
 	}
 }

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -32,10 +32,16 @@ type Message struct {
 	Body      []byte
 	CreatedAt time.Time
 	// Cursor is an opaque, plugin-defined value for resuming
-	// Output(). Coda treats it as a black box — persist it from one
-	// call's response and echo it back on the next call's since
-	// argument. Empty string means "no cursor yet".
-	Cursor string
+	// Output(). Providers MUST return Output() messages in the
+	// same stream order they want cursor advancement to follow
+	// (typically oldest to newest). Coda does not compare, sort,
+	// or interpret cursor values; after a successful Output() call
+	// it persists the Cursor from the last message in the returned
+	// slice whose Cursor is non-empty, and echoes that exact value
+	// back on the next call's since argument. If no message in the
+	// slice has a non-empty Cursor, coda leaves the persisted
+	// cursor unchanged. Empty string means "no cursor yet".
+	Cursor string `json:",omitempty"`
 }
 
 // Status is a provider-reported session health snapshot.

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -13,7 +13,7 @@ type Provider interface {
 	Stop(sessionID string) error
 	Deliver(sessionID string, msg Message) (delivered bool, err error)
 	Health(sessionID string) (Status, error)
-	Output(sessionID string, since *time.Time) ([]Message, error)
+	Output(sessionID string, since string) ([]Message, error)
 	Attach(sessionID string) error
 }
 
@@ -21,6 +21,9 @@ type Provider interface {
 // provider session. It is the same shape used by the messaging
 // primitive (card #170), defined here to keep the Provider interface
 // self-contained for now. Card #170 may move it.
+//
+// Cursor is opaque to coda — plugins define its format and coda
+// round-trips it unchanged between Output calls.
 type Message struct {
 	ID        string
 	From      string
@@ -28,6 +31,11 @@ type Message struct {
 	Type      string
 	Body      []byte
 	CreatedAt time.Time
+	// Cursor is an opaque, plugin-defined value for resuming
+	// Output(). Coda treats it as a black box — persist it from one
+	// call's response and echo it back on the next call's since
+	// argument. Empty string means "no cursor yet".
+	Cursor string
 }
 
 // Status is a provider-reported session health snapshot.


### PR DESCRIPTION
## Summary

Change `Provider.Output(sessionID string, since *time.Time)` to `Output(sessionID string, since string)` and add a `Cursor string` field to `session.Message`, so plugins pass an opaque cursor instead of an RFC3339 timestamp.

This is a **free interface change** — `Output` has no production callers yet. It is a precondition for Card B.

## Context

- Card #205 (this work)
- [evanstern/coda-codaclaw#3](https://github.com/evanstern/coda-codaclaw/issues/3) — Card B, the consumer of this interface change
- [evanstern/codaclaw#8](https://github.com/evanstern/codaclaw/pull/8) merged at `93e1526` — Card A, which motivated the cursor-protocol change by replacing RFC3339 timestamps with opaque seq-based cursors

## Changes

- `internal/session/provider.go` — interface signature `*time.Time` → `string`; added `Cursor string` field to `Message`
- `internal/plugin/provider.go` — `SubprocessProvider.Output` signature + argv updated; removed unused `time` import
- `internal/plugin/provider_test.go` — call site updated to string cursor; added `Cursor` round-trip assertion
- `internal/messages/router_test.go` — `fakeProvider.Output` signature updated
- `cmd/coda/main_test.go` — `stubProvider.Output` signature updated
- `docs/plugin-contracts/providers.md` — table row updated; added cursor protocol section

Closes #205